### PR TITLE
fix(oidc): 修正请求 token 阶段的请求包

### DIFF
--- a/api/oauth.go
+++ b/api/oauth.go
@@ -19,9 +19,7 @@ func OAuth(c *gin.Context) {
 		return
 	}
 
-	redirectURI := utils.GetScheme(c) + "://" + c.Request.Host + "/api/oauth_callback"
-
-	authURL, state := oauth.CurrentProvider().GetAuthorizationURL(redirectURI)
+	authURL, state := oauth.CurrentProvider().GetAuthorizationURL(utils.GetCallbackURL(c))
 
 	c.SetCookie("oauth_state", state, 3600, "/", "", false, true)
 
@@ -44,7 +42,7 @@ func OAuthCallback(c *gin.Context) {
 			queries[key] = values[0]
 		}
 	}
-	oidcUser, err := oauth.CurrentProvider().OnCallback(c.Request.Context(), state, queries)
+	oidcUser, err := oauth.CurrentProvider().OnCallback(c.Request.Context(), state, queries, utils.GetCallbackURL(c))
 	if err != nil {
 		c.JSON(500, gin.H{"status": "error", "error": "Failed to get user info: " + err.Error()})
 		return

--- a/utils/gin.go
+++ b/utils/gin.go
@@ -23,3 +23,9 @@ func GetScheme(c *gin.Context) string {
 	}
 	return "http"
 }
+
+func GetCallbackURL(c *gin.Context) string {
+	scheme := GetScheme(c)
+	host := c.Request.Host
+	return scheme + "://" + host + "/api/oauth_callback"
+}

--- a/utils/oauth/factory/meta.go
+++ b/utils/oauth/factory/meta.go
@@ -8,7 +8,7 @@ type IOidcProvider interface {
 	GetConfiguration() Configuration
 	// 获取授权URL和状态
 	GetAuthorizationURL(redirectURI string) (string, string)
-	OnCallback(ctx context.Context, state string, query map[string]string) (OidcCallback, error)
+	OnCallback(ctx context.Context, state string, query map[string]string, callbackURI string) (OidcCallback, error)
 	Init() error
 	Destroy() error
 }

--- a/utils/oauth/github/github.go
+++ b/utils/oauth/github/github.go
@@ -36,7 +36,7 @@ func (g *Github) GetAuthorizationURL(_ string) (string, string) {
 	g.stateCache.Set(state, true, cache.NoExpiration)
 	return authURL, state
 }
-func (g *Github) OnCallback(ctx context.Context, state string, query map[string]string) (factory.OidcCallback, error) {
+func (g *Github) OnCallback(ctx context.Context, state string, query map[string]string, _ string) (factory.OidcCallback, error) {
 	code := query["code"]
 
 	// 验证state防止CSRF攻击


### PR DESCRIPTION
发现昨天改少了，还是不能用

https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3

> redirect_uri
> REQUIRED, if the "redirect_uri" parameter was included in the authorization request as described in [Section 4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1), and their values MUST be identical.

在 Access Token Request 阶段也加上了 redirect_uri 字段

>     POST /token HTTP/1.1
>     Host: server.example.com
>     Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
>     Content-Type: application/x-www-form-urlencoded
>
>     grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA&redirect_uri=https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb

请求应该以 application/x-www-form-urlencoded 的形式放在 POST data 里而不是放在 GET Params 里