### PR TITLE
feat: 添加 Cloudflare Access 认证集成

### DIFF
--- a/api/CloudflareAccessMiddleware.go
+++ b/api/CloudflareAccessMiddleware.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/gin-gonic/gin"
+	"github.com/komari-monitor/komari/database/accounts"
+	"github.com/komari-monitor/komari/database/auditlog"
+	"github.com/komari-monitor/komari/database/dbcore"
+	"github.com/komari-monitor/komari/database/models"
+)
+
+// CloudflareAccessMiddleware 处理 Cloudflare Access 认证
+func CloudflareAccessMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// 检查是否启用了 Cloudflare Access
+		cfAccessEnabled := strings.ToLower(os.Getenv("KOMARI_CF_ACCESS_ENABLED")) == "true"
+		if !cfAccessEnabled {
+			c.Next()
+			return
+		}
+
+		// 获取 Cloudflare Access JWT token
+		jwtToken := c.GetHeader("Cf-Access-Jwt-Assertion")
+		
+		// 如果没有 JWT token，继续正常流程
+		if jwtToken == "" {
+			c.Next()
+			return
+		}
+
+		// 先检查是否已经有有效的 session，避免不必要的 JWT 验证
+		if session, err := c.Cookie("session_token"); err == nil {
+			if _, err := accounts.GetSession(session); err == nil {
+				// 已经有有效session，更新最后活动时间并继续
+				accounts.UpdateLatest(session, c.Request.UserAgent(), c.ClientIP())
+				c.Next()
+				return
+			}
+		}
+
+		// 只有在没有有效 session 时才验证 JWT token
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+		
+		claims, err := validateCloudflareJWT(ctx, jwtToken)
+		if err != nil {
+			log.Printf("Cloudflare Access: JWT validation failed: %v", err)
+			c.Next()
+			return
+		}
+
+		// 尝试根据邮箱获取用户
+		uuid, err := getUserByEmail(claims.Email)
+		if err != nil {
+			log.Printf("Cloudflare Access: Failed to get user for email %s: %v", claims.Email, err)
+			c.Next()
+			return
+		}
+
+		// 创建新的 session
+		session, err := accounts.CreateSession(uuid, 2592000, c.Request.UserAgent(), c.ClientIP(), "cloudflare_access")
+		if err != nil {
+			log.Printf("Cloudflare Access: Failed to create session for user %s: %v", uuid, err)
+			c.Next()
+			return
+		}
+
+		// 设置 session cookie
+		c.SetCookie("session_token", session, 2592000, "/", "", false, true)
+		
+		// 记录审计日志
+		auditlog.Log(c.ClientIP(), uuid, "logged in (Cloudflare Access)", "login")
+		
+		log.Printf("Cloudflare Access: User %s automatically logged in via JWT", claims.Email)
+		
+		c.Next()
+	}
+}
+
+// getUserByEmail 根据邮箱获取用户
+func getUserByEmail(email string) (string, error) {
+	// 获取默认管理员邮箱配置
+	adminEmail := os.Getenv("KOMARI_CF_ACCESS_ADMIN_EMAIL")
+	
+	// CloudFlare Access登入邮箱匹配
+	if adminEmail != "" && strings.ToLower(email) == strings.ToLower(adminEmail) {
+		// 获取第一个用户（默认管理员）
+		db := dbcore.GetDBInstance()
+		var user models.User
+		err := db.First(&user).Error
+		if err != nil {
+			return "", err
+		}
+		return user.UUID, nil
+	}
+	
+	// 对于非管理员邮箱，或空
+	// 不允许自动登入
+	if adminEmail == "" || strings.ToLower(email) != strings.ToLower(adminEmail) {
+		log.Printf("Cloudflare Access: Email %s is not configured as admin email", email)
+		return "", fmt.Errorf("Email not authorized for access")
+	}
+
+	// 如果没有找到管理员用户，返回错误
+	return "", fmt.Errorf("No admin user found")
+}
+
+
+// CloudflareAccessClaims JWT claims 结构
+type CloudflareAccessClaims struct {
+	// 只获取需要的 email
+	Email string `json:"email"`
+}
+
+// validateCloudflareJWT 验证 Cloudflare Access JWT token
+func validateCloudflareJWT(ctx context.Context, token string) (*CloudflareAccessClaims, error) {
+	// 获取环境变量
+	teamName := os.Getenv("KOMARI_CF_ACCESS_TEAM_NAME")
+	if teamName == "" {
+		return nil, fmt.Errorf("KOMARI_CF_ACCESS_TEAM_NAME environment variable not set")
+	}
+	
+	audience := os.Getenv("KOMARI_CF_ACCESS_AUDIENCE")
+	if audience == "" {
+		return nil, fmt.Errorf("KOMARI_CF_ACCESS_AUDIENCE environment variable not set")
+	}
+
+	// 构建验证器
+	teamDomain := fmt.Sprintf("https://%s.cloudflareaccess.com", teamName)
+	certsURL := fmt.Sprintf("%s/cdn-cgi/access/certs", teamDomain)
+
+	config := &oidc.Config{
+		ClientID: audience,
+	}
+
+	keySet := oidc.NewRemoteKeySet(ctx, certsURL)
+	verifier := oidc.NewVerifier(teamDomain, keySet, config)
+
+	// 验证 JWT token
+	idToken, err := verifier.Verify(ctx, token)
+	if err != nil {
+		return nil, fmt.Errorf("token verification failed: %v", err)
+	}
+
+	// 解析 claims
+	var claims CloudflareAccessClaims
+	if err := idToken.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("failed to parse claims: %v", err)
+	}
+
+	return &claims, nil
+}

--- a/api/cloudflare_access_test.go
+++ b/api/cloudflare_access_test.go
@@ -1,0 +1,410 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/komari-monitor/komari/database/accounts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudflareAccessMiddleware(t *testing.T) {
+	// 设置测试模式
+	gin.SetMode(gin.TestMode)
+	
+	// 创建测试用户
+	accounts.CreateAccount("testuser", "testpassword")
+	defer accounts.DeleteAccountByUsername("testuser")
+	defer accounts.DeleteAllSessions()
+
+	tests := []struct {
+		name                string
+		cfAccessEnabled     string
+		adminEmail          string
+		teamName            string
+		audience            string
+		jwtToken            string
+		existingSession     string
+		expectedStatusCode  int
+		expectedSetCookie   bool
+	}{
+		{
+			name:               "CF Access disabled - should continue normally",
+			cfAccessEnabled:    "false",
+			jwtToken:           "valid-jwt-token",
+			expectedStatusCode: http.StatusOK,
+			expectedSetCookie:  false,
+		},
+		{
+			name:               "No JWT token - should continue normally",
+			cfAccessEnabled:    "true",
+			adminEmail:         "admin@test.com",
+			teamName:           "test-team",
+			audience:           "test-audience",
+			jwtToken:           "",
+			expectedStatusCode: http.StatusOK,
+			expectedSetCookie:  false,
+		},
+		{
+			name:               "Valid existing session - should skip JWT validation",
+			cfAccessEnabled:    "true",
+			adminEmail:         "admin@test.com",
+			teamName:           "test-team",
+			audience:           "test-audience",
+			jwtToken:           "valid-jwt-token",
+			existingSession:    "valid-session",
+			expectedStatusCode: http.StatusOK,
+			expectedSetCookie:  false,
+		},
+		{
+			name:               "Valid JWT with admin email - should create session (will fail JWT validation but continue)",
+			cfAccessEnabled:    "true",
+			adminEmail:         "admin@test.com",
+			teamName:           "test-team",
+			audience:           "test-audience",
+			jwtToken:           "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImFkbWluQHRlc3QuY29tIn0.fake-signature",
+			expectedStatusCode: http.StatusOK,
+			expectedSetCookie:  false, // Will be false because JWT validation will fail in test
+		},
+		{
+			name:               "Valid JWT with non-admin email - should continue normally",
+			cfAccessEnabled:    "true",
+			adminEmail:         "admin@test.com",
+			teamName:           "test-team",
+			audience:           "test-audience",
+			jwtToken:           "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InVzZXJAdGVzdC5jb20ifQ.fake-signature",
+			expectedStatusCode: http.StatusOK,
+			expectedSetCookie:  false,
+		},
+		{
+			name:               "Invalid JWT token - should continue normally",
+			cfAccessEnabled:    "true",
+			adminEmail:         "admin@test.com",
+			teamName:           "test-team",
+			audience:           "test-audience",
+			jwtToken:           "invalid-jwt-token",
+			expectedStatusCode: http.StatusOK,
+			expectedSetCookie:  false,
+		},
+		{
+			name:               "Missing team name - should continue normally",
+			cfAccessEnabled:    "true",
+			adminEmail:         "admin@test.com",
+			teamName:           "",
+			audience:           "test-audience",
+			jwtToken:           "valid-jwt-token",
+			expectedStatusCode: http.StatusOK,
+			expectedSetCookie:  false,
+		},
+		{
+			name:               "Missing audience - should continue normally",
+			cfAccessEnabled:    "true",
+			adminEmail:         "admin@test.com",
+			teamName:           "test-team",
+			audience:           "",
+			jwtToken:           "valid-jwt-token",
+			expectedStatusCode: http.StatusOK,
+			expectedSetCookie:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 设置环境变量
+			os.Setenv("KOMARI_CF_ACCESS_ENABLED", tt.cfAccessEnabled)
+			os.Setenv("KOMARI_CF_ACCESS_ADMIN_EMAIL", tt.adminEmail)
+			os.Setenv("KOMARI_CF_ACCESS_TEAM_NAME", tt.teamName)
+			os.Setenv("KOMARI_CF_ACCESS_AUDIENCE", tt.audience)
+			
+			defer func() {
+				os.Unsetenv("KOMARI_CF_ACCESS_ENABLED")
+				os.Unsetenv("KOMARI_CF_ACCESS_ADMIN_EMAIL")
+				os.Unsetenv("KOMARI_CF_ACCESS_TEAM_NAME")
+				os.Unsetenv("KOMARI_CF_ACCESS_AUDIENCE")
+			}()
+
+			// 创建测试路由
+			router := gin.New()
+			router.Use(CloudflareAccessMiddleware())
+			router.GET("/test", func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"message": "success"})
+			})
+
+			// 创建测试请求
+			req, _ := http.NewRequest("GET", "/test", nil)
+			
+			// 设置 JWT token header
+			if tt.jwtToken != "" {
+				req.Header.Set("Cf-Access-Jwt-Assertion", tt.jwtToken)
+			}
+
+			// 设置现有 session cookie
+			if tt.existingSession != "" {
+				// 创建一个有效的 session
+				uuid, _ := accounts.CheckPassword("testuser", "testpassword")
+				session, _ := accounts.CreateSession(uuid, 3600, "test-agent", "127.0.0.1", "test")
+				req.AddCookie(&http.Cookie{
+					Name:  "session_token",
+					Value: session,
+				})
+			}
+
+			// 创建响应记录器
+			w := httptest.NewRecorder()
+
+			// 执行请求
+			router.ServeHTTP(w, req)
+
+			// 断言状态码
+			assert.Equal(t, tt.expectedStatusCode, w.Code)
+
+			// 检查是否设置了 session cookie
+			cookies := w.Result().Cookies()
+			sessionCookieSet := false
+			for _, cookie := range cookies {
+				if cookie.Name == "session_token" && cookie.Value != "" {
+					sessionCookieSet = true
+					break
+				}
+			}
+			assert.Equal(t, tt.expectedSetCookie, sessionCookieSet)
+
+			// 解析响应体
+			var response map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			assert.Equal(t, "success", response["message"])
+		})
+	}
+}
+
+func TestGetUserByEmail(t *testing.T) {
+	// 创建测试用户
+	accounts.CreateAccount("testuser", "testpassword")
+	defer accounts.DeleteAccountByUsername("testuser")
+
+	tests := []struct {
+		name        string
+		email       string
+		adminEmail  string
+		expectError bool
+		errorType   string
+	}{
+		{
+			name:        "Valid admin email - should return user UUID",
+			email:       "admin@test.com",
+			adminEmail:  "admin@test.com",
+			expectError: false,
+		},
+		{
+			name:        "Case insensitive admin email - should return user UUID",
+			email:       "ADMIN@TEST.COM",
+			adminEmail:  "admin@test.com",
+			expectError: false,
+		},
+		{
+			name:        "Non-admin email - should return error",
+			email:       "user@test.com",
+			adminEmail:  "admin@test.com",
+			expectError: true,
+			errorType:   "Email not authorized for access",
+		},
+		{
+			name:        "Empty admin email config - should return error",
+			email:       "admin@test.com",
+			adminEmail:  "",
+			expectError: true,
+			errorType:   "Email not authorized for access",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 设置环境变量
+			os.Setenv("KOMARI_CF_ACCESS_ADMIN_EMAIL", tt.adminEmail)
+			defer os.Unsetenv("KOMARI_CF_ACCESS_ADMIN_EMAIL")
+
+			// 调用函数
+			uuid, err := getUserByEmail(tt.email)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorType != "" {
+					assert.Contains(t, err.Error(), tt.errorType)
+				}
+				assert.Empty(t, uuid)
+			} else {
+				assert.NoError(t, err)
+				assert.NotEmpty(t, uuid)
+			}
+		})
+	}
+}
+
+func TestValidateCloudflareJWT(t *testing.T) {
+	tests := []struct {
+		name        string
+		teamName    string
+		audience    string
+		token       string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "Missing team name - should return error",
+			teamName:    "",
+			audience:    "test-audience",
+			token:       "test-token",
+			expectError: true,
+			errorMsg:    "KOMARI_CF_ACCESS_TEAM_NAME environment variable not set",
+		},
+		{
+			name:        "Missing audience - should return error",
+			teamName:    "test-team",
+			audience:    "",
+			token:       "test-token",
+			expectError: true,
+			errorMsg:    "KOMARI_CF_ACCESS_AUDIENCE environment variable not set",
+		},
+		{
+			name:        "Invalid token format - should return error",
+			teamName:    "test-team",
+			audience:    "test-audience",
+			token:       "invalid-token",
+			expectError: true,
+			errorMsg:    "token verification failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 设置环境变量
+			os.Setenv("KOMARI_CF_ACCESS_TEAM_NAME", tt.teamName)
+			os.Setenv("KOMARI_CF_ACCESS_AUDIENCE", tt.audience)
+			
+			defer func() {
+				os.Unsetenv("KOMARI_CF_ACCESS_TEAM_NAME")
+				os.Unsetenv("KOMARI_CF_ACCESS_AUDIENCE")
+			}()
+
+			// 创建上下文
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			// 调用函数
+			claims, err := validateCloudflareJWT(ctx, tt.token)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+				assert.Nil(t, claims)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, claims)
+			}
+		})
+	}
+}
+
+func TestLogoutWithCloudflareAccess(t *testing.T) {
+	// 设置测试模式
+	gin.SetMode(gin.TestMode)
+	
+	// 创建测试用户和 session
+	accounts.CreateAccount("testuser", "testpassword")
+	uuid, _ := accounts.CheckPassword("testuser", "testpassword")
+	session, _ := accounts.CreateSession(uuid, 3600, "test-agent", "127.0.0.1", "test")
+	
+	defer func() {
+		accounts.DeleteAccountByUsername("testuser")
+		accounts.DeleteAllSessions()
+	}()
+
+	tests := []struct {
+		name               string
+		cfAccessEnabled    string
+		teamName           string
+		expectedStatusCode int
+		expectedLocation   string
+	}{
+		{
+			name:               "CF Access disabled - should redirect to root",
+			cfAccessEnabled:    "false",
+			teamName:           "",
+			expectedStatusCode: http.StatusFound,
+			expectedLocation:   "/",
+		},
+		{
+			name:               "CF Access enabled without team name - should redirect to root",
+			cfAccessEnabled:    "true",
+			teamName:           "",
+			expectedStatusCode: http.StatusFound,
+			expectedLocation:   "/",
+		},
+		{
+			name:               "CF Access enabled with team name - should redirect to CF logout",
+			cfAccessEnabled:    "true",
+			teamName:           "test-team",
+			expectedStatusCode: http.StatusFound,
+			expectedLocation:   "https://test-team.cloudflareaccess.com/cdn-cgi/access/logout?returnTo=http%3A%2F%2Fexample.com%2F",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 设置环境变量
+			os.Setenv("KOMARI_CF_ACCESS_ENABLED", tt.cfAccessEnabled)
+			os.Setenv("KOMARI_CF_ACCESS_TEAM_NAME", tt.teamName)
+			
+			defer func() {
+				os.Unsetenv("KOMARI_CF_ACCESS_ENABLED")
+				os.Unsetenv("KOMARI_CF_ACCESS_TEAM_NAME")
+			}()
+
+			// 创建测试路由
+			router := gin.New()
+			router.POST("/logout", Logout)
+
+			// 创建测试请求
+			req, _ := http.NewRequest("POST", "/logout", nil)
+			req.Host = "example.com"
+			req.AddCookie(&http.Cookie{
+				Name:  "session_token",
+				Value: session,
+			})
+
+			// 创建响应记录器
+			w := httptest.NewRecorder()
+
+			// 执行请求
+			router.ServeHTTP(w, req)
+
+			// 断言状态码
+			assert.Equal(t, tt.expectedStatusCode, w.Code)
+
+			// 断言重定向位置
+			location := w.Header().Get("Location")
+			assert.Equal(t, tt.expectedLocation, location)
+
+			// 检查 session cookie 是否被清除
+			cookies := w.Result().Cookies()
+			sessionCookieCleared := false
+			for _, cookie := range cookies {
+				if cookie.Name == "session_token" && cookie.Value == "" && cookie.MaxAge == -1 {
+					sessionCookieCleared = true
+					break
+				}
+			}
+			assert.True(t, sessionCookieCleared, "Session cookie should be cleared")
+		})
+	}
+}
+

--- a/api/login.go
+++ b/api/login.go
@@ -2,8 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
 
 	"github.com/komari-monitor/komari/database/accounts"
 	"github.com/komari-monitor/komari/database/auditlog"
@@ -72,6 +76,26 @@ func Logout(c *gin.Context) {
 	session, _ := c.Cookie("session_token")
 	accounts.DeleteSession(session)
 	c.SetCookie("session_token", "", -1, "/", "", false, true)
+	
+	// 检查是否启用了 Cloudflare Access
+	cfAccessEnabled := strings.ToLower(os.Getenv("KOMARI_CF_ACCESS_ENABLED")) == "true"
+	teamName := os.Getenv("KOMARI_CF_ACCESS_TEAM_NAME")
+	
+	if cfAccessEnabled && teamName != "" {
+		// 同时退出Cloudflare Access，退出后重定向回根目录
+		auditlog.Log(c.ClientIP(), "", "logged out (Cloudflare Access)", "logout")
+		// 构建当前域名的根目录 URL
+		scheme := "https"
+		if c.Request.TLS == nil {
+			scheme = "http"
+		}
+		returnTo := fmt.Sprintf("%s://%s/", scheme, c.Request.Host)
+		logoutURL := fmt.Sprintf("https://%s.cloudflareaccess.com/cdn-cgi/access/logout?returnTo=%s", teamName, url.QueryEscape(returnTo))
+		c.Redirect(302, logoutURL)
+		return
+	}
+	
+	// 普通退出
 	auditlog.Log(c.ClientIP(), "", "logged out", "logout")
 	c.Redirect(302, "/")
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -139,6 +139,8 @@ func RunServer() {
 		c.Next()
 	})
 
+	// Cloudflare Access 中间件
+	r.Use(api.CloudflareAccessMiddleware())
 	r.Use(api.PrivateSiteMiddleware())
 
 	r.Use(func(c *gin.Context) {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	gorm.io/driver/mysql v1.5.7
 	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.26.1
-
 )
 
 // Misuse of ServerConfig.PublicKeyCallback may cause authorization bypass in golang.org/x/crypto #1
@@ -31,9 +30,11 @@ require (
 	github.com/bytedance/sonic v1.13.2 // indirect
 	github.com/bytedance/sonic/loader v0.2.4 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
+	github.com/coreos/go-oidc/v3 v3.15.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.0.0 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
@@ -58,6 +59,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.15.0 // indirect
+	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFos
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
 github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
+github.com/coreos/go-oidc/v3 v3.15.0 h1:R6Oz8Z4bqWR7VFQ+sPSvZPQv4x8M+sJkDO5ojgwlyAg=
+github.com/coreos/go-oidc/v3 v3.15.0/go.mod h1:HaZ3szPaZ0e4r6ebqvsLWlk2Tn+aejfmrfah6hnSYEU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -21,6 +23,8 @@ github.com/gin-contrib/sse v1.0.0 h1:y3bT1mUWUxDpW4JLQg/HnTqV4rozuW4tC9eFKTxYI9E
 github.com/gin-contrib/sse v1.0.0/go.mod h1:zNuFdwarAygJBht0NTKiSi3jRf6RbqeILZ9Sp6Slhe0=
 github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=
 github.com/gin-gonic/gin v1.10.0/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -113,6 +117,8 @@ golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
 golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
+golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
 golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
- 新增 CloudflareAccessMiddleware 中间件实现 Cloudflare Access 自动登录
- 增强登出流程支持 Cloudflare Access 登出重定向
- 更新依赖 添加go-oidc，用于JWT的读取和校验
- 添加新的环境变量用于Cloudflare Access功能配置
  - KOMARI_CF_ACCESS_ENABLED：控制是否启用 Cloudflare Access 功能。字符串"true"为启用
  - KOMARI_CF_ACCESS_ADMIN_EMAIL：指定管理员邮箱地址，只有匹配此邮箱的 Cloudflare Access 用户才能自动登录系统
  - KOMARI_CF_ACCESS_TEAM_NAME：Cloudflare Access 团队名称。用于构建 Cloudflare Access 的验证 URL (https://{team_name}.cloudflareaccess.com)
  - KOMARI_CF_ACCESS_AUDIENCE：Cloudflare Access 应用程序的 Audience 标识符。用于 JWT token 的 audience 验证，确保 token 是为此应用程序签发的

最终效果：通过Cloudflare Access认证后，无需再次在komari中进行身份认证，自动登入
已知问题：
- 退出登入后，旧JWT令牌在有效期内仍可使用。
- Cloudflare Access退出有延迟，重新被Access拦截请求需要一段时间（取决于Cloudflare节点刷新）

以上两个问题均会导致点了退出按钮，回到主页还是登入的状态
***
本来想加到UI也可配置，但是Cloudflare Access和OAuth里哪些认证方式都不太一样，不是走OAuth流程的。接进去的话要改OAuth逻辑，感觉不是很好，就先弄了个环境变量的。
