### PR TITLE
feat: 添加对 Cloudflare Access 的支持

### DIFF
--- a/api/admin/oauth.go
+++ b/api/admin/oauth.go
@@ -8,6 +8,7 @@ import (
 	"github.com/komari-monitor/komari/database/config"
 	"github.com/komari-monitor/komari/database/models"
 	"github.com/komari-monitor/komari/utils/oauth"
+	"github.com/komari-monitor/komari/utils/oauth/cloudflare/handler"
 	"github.com/komari-monitor/komari/utils/oauth/factory"
 )
 
@@ -75,6 +76,14 @@ func SetOidcProvider(c *gin.Context) {
 		api.RespondError(c, 404, "Provider not found: "+oidcConfig.Name)
 		return
 	}
+	// 对于 Cloudflare Access 提供商，使用专用处理器
+	if oidcConfig.Name == "cloudflare_access" {
+		if err := handler.HandleSetOidcProvider(&oidcConfig); err != nil {
+			api.RespondError(c, 500, "Failed to configure Cloudflare provider: "+err.Error())
+			return
+		}
+	}
+	
 	if err := database.SaveOidcConfig(&oidcConfig); err != nil {
 		api.RespondError(c, 500, "Failed to save OIDC provider configuration: "+err.Error())
 		return

--- a/go.mod
+++ b/go.mod
@@ -31,9 +31,11 @@ require (
 	github.com/bytedance/sonic v1.13.2 // indirect
 	github.com/bytedance/sonic/loader v0.2.4 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
+	github.com/coreos/go-oidc/v3 v3.15.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.0.0 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
@@ -58,6 +60,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.15.0 // indirect
+	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFos
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
 github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
+github.com/coreos/go-oidc/v3 v3.15.0 h1:R6Oz8Z4bqWR7VFQ+sPSvZPQv4x8M+sJkDO5ojgwlyAg=
+github.com/coreos/go-oidc/v3 v3.15.0/go.mod h1:HaZ3szPaZ0e4r6ebqvsLWlk2Tn+aejfmrfah6hnSYEU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -21,6 +23,8 @@ github.com/gin-contrib/sse v1.0.0 h1:y3bT1mUWUxDpW4JLQg/HnTqV4rozuW4tC9eFKTxYI9E
 github.com/gin-contrib/sse v1.0.0/go.mod h1:zNuFdwarAygJBht0NTKiSi3jRf6RbqeILZ9Sp6Slhe0=
 github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=
 github.com/gin-gonic/gin v1.10.0/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -113,6 +117,8 @@ golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
 golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
+golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
 golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/utils/oauth/all.go
+++ b/utils/oauth/all.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	_ "github.com/komari-monitor/komari/utils/oauth/cloudflare"
 	_ "github.com/komari-monitor/komari/utils/oauth/factory"
 	_ "github.com/komari-monitor/komari/utils/oauth/generic"
 	_ "github.com/komari-monitor/komari/utils/oauth/github"

--- a/utils/oauth/cloudflare/cloudflare.go
+++ b/utils/oauth/cloudflare/cloudflare.go
@@ -1,0 +1,86 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/komari-monitor/komari/utils/oauth/factory"
+)
+
+func (c *Cloudflare) GetName() string {
+	return "cloudflare_access"
+}
+
+func (c *Cloudflare) GetConfiguration() factory.Configuration {
+	return &c.Addition
+}
+
+func (c *Cloudflare) GetAuthorizationURL(redirectURI string) (string, string) {
+	// Cloudflare Access 不需要跳转，直接返回回调 URL
+	// 前端应该直接调用回调接口
+	return redirectURI, ""
+}
+
+func (c *Cloudflare) OnCallback(ctx context.Context, state string, query map[string]string, callbackURI string) (factory.OidcCallback, error) {
+	// 从请求头中获取 Cloudflare Access JWT
+	accessJWT := query["cf_access_jwt"]
+	if accessJWT == "" {
+		return factory.OidcCallback{}, fmt.Errorf("no Cloudflare Access JWT found")
+	}
+
+	// 验证 JWT
+	teamDomain := c.Addition.TeamDomain
+	// 如果不是完整的URL，则默认添加 https 前缀和 cloudflareaccess.com 后缀
+	if !strings.HasPrefix(teamDomain, "https://") {
+		teamDomain = "https://" + teamDomain + ".cloudflareaccess.com"
+	}
+
+	certsURL := fmt.Sprintf("%s/cdn-cgi/access/certs", teamDomain)
+	
+	config := &oidc.Config{
+		ClientID: c.Addition.PolicyAUD,
+	}
+	
+	keySet := oidc.NewRemoteKeySet(ctx, certsURL)
+	verifier := oidc.NewVerifier(teamDomain, keySet, config)
+	
+	// 验证 token
+	idToken, err := verifier.Verify(ctx, accessJWT)
+	if err != nil {
+		return factory.OidcCallback{}, fmt.Errorf("failed to verify Cloudflare Access token: %w", err)
+	}
+	
+	// 提取用户信息
+	var claims struct {
+		// Email string `json:"email"`
+		Sub   string `json:"sub"`
+	}
+	
+	if err := idToken.Claims(&claims); err != nil {
+		return factory.OidcCallback{}, fmt.Errorf("failed to extract claims from token: %w", err)
+	}
+	
+	// 使用 sub 作为用户 ID
+	return factory.OidcCallback{UserId: claims.Sub}, nil
+}
+
+func (c *Cloudflare) Init() error {
+	// 验证配置
+	if c.Addition.TeamDomain == "" {
+		return fmt.Errorf("team_domain is required")
+	}
+	if c.Addition.PolicyAUD == "" {
+		return fmt.Errorf("policy_aud is required")
+	}
+	
+	return nil
+}
+
+func (c *Cloudflare) Destroy() error {
+	// Cloudflare Access 提供商不需要特殊的清理操作
+	return nil
+}
+
+var _ factory.IOidcProvider = (*Cloudflare)(nil)

--- a/utils/oauth/cloudflare/handler/handler.go
+++ b/utils/oauth/cloudflare/handler/handler.go
@@ -1,0 +1,115 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/komari-monitor/komari/database/accounts"
+	"github.com/komari-monitor/komari/database/auditlog"
+	"github.com/komari-monitor/komari/database/models"
+	"github.com/komari-monitor/komari/utils"
+	"github.com/komari-monitor/komari/utils/oauth"
+)
+
+// CloudflareConfig Cloudflare 配置结构
+type CloudflareConfig struct {
+	TeamDomain string `json:"team_domain"`
+	PolicyAUD  string `json:"policy_aud"`
+}
+
+// HandleOAuth 处理 Cloudflare OAuth 请求（直接认证，不跳转）
+func HandleOAuth(c *gin.Context) {
+	HandleOAuthCallback(c)
+}
+
+// HandleOAuthCallback 处理 Cloudflare OAuth 回调
+func HandleOAuthCallback(c *gin.Context) {
+	// 从请求头获取 JWT
+	accessJWT := c.GetHeader("Cf-Access-Jwt-Assertion")
+	if accessJWT == "" {
+		c.JSON(401, gin.H{"status": "error", "message": "No Cloudflare Access JWT found"})
+		return
+	}
+
+	// 构造查询参数
+	queries := map[string]string{
+		"cf_access_jwt": accessJWT,
+	}
+
+	// 调用 OAuth 提供商验证
+	oidcUser, err := oauth.CurrentProvider().OnCallback(c.Request.Context(), "", queries, utils.GetCallbackURL(c))
+	if err != nil {
+		c.JSON(500, gin.H{"status": "error", "message": "Failed to verify Cloudflare Access token: " + err.Error()})
+		return
+	}
+
+	// 生成 SSO ID
+	ssoID := fmt.Sprintf("cloudflare_access_%s", oidcUser.UserId)
+
+	// 检查是否为绑定外部账号流程
+	uuid, _ := c.Cookie("binding_external_account")
+	c.SetCookie("binding_external_account", "", -1, "/", "", false, true)
+	if uuid != "" {
+		// 绑定外部账号
+		session, _ := c.Cookie("session_token")
+		user, err := accounts.GetUserBySession(session)
+		if err != nil || user.UUID != uuid {
+			c.JSON(500, gin.H{"status": "error", "message": "Binding failed"})
+			return
+		}
+		err = accounts.BindingExternalAccount(user.UUID, ssoID)
+		if err != nil {
+			c.JSON(500, gin.H{"status": "error", "message": "Binding failed"})
+			return
+		}
+		auditlog.Log(c.ClientIP(), user.UUID, "bound external account (Cloudflare Access)"+fmt.Sprintf(",sso_id: %s", ssoID), "login")
+		c.Redirect(302, "/manage")
+		return
+	}
+
+	// 尝试获取用户（登录流程）
+	user, err := accounts.GetUserBySSO(ssoID)
+	if err != nil {
+		c.JSON(401, gin.H{
+			"status":  "error",
+			"message": "please log in and bind your external account first.",
+		})
+		return
+	}
+
+	// 创建会话
+	session, err := accounts.CreateSession(user.UUID, 2592000, c.Request.UserAgent(), c.ClientIP(), "cloudflare_access")
+	if err != nil {
+		c.JSON(500, gin.H{"status": "error", "message": err.Error()})
+		return
+	}
+
+	// 设置 cookie 并返回
+	c.SetCookie("session_token", session, 2592000, "/", "", false, true)
+	auditlog.Log(c.ClientIP(), user.UUID, "logged in (Cloudflare Access)", "login")
+	c.Redirect(302, "/admin")
+}
+
+// HandleSetOidcProvider 处理 Cloudflare OIDC 提供商配置
+func HandleSetOidcProvider(oidcConfig *models.OidcProvider) error {
+	// 解析 Cloudflare 配置进行验证
+	var cloudflareConfig CloudflareConfig
+	if err := json.Unmarshal([]byte(oidcConfig.Addition), &cloudflareConfig); err != nil {
+		return fmt.Errorf("failed to parse Cloudflare config: %w", err)
+	}
+
+	if cloudflareConfig.TeamDomain == "" {
+		return fmt.Errorf("team_domain is required for Cloudflare provider")
+	}
+
+	if cloudflareConfig.PolicyAUD == "" {
+		return fmt.Errorf("policy_aud is required for Cloudflare provider")
+	}
+	return nil
+}
+
+// IsCloudflareProvider 检查当前是否为 Cloudflare Access 提供商
+func IsCloudflareProvider() bool {
+	return oauth.CurrentProvider().GetName() == "cloudflare_access"
+}

--- a/utils/oauth/cloudflare/meta.go
+++ b/utils/oauth/cloudflare/meta.go
@@ -1,0 +1,20 @@
+package cloudflare
+
+import (
+	"github.com/komari-monitor/komari/utils/oauth/factory"
+)
+
+func init() {
+	factory.RegisterOidcProvider(func() factory.IOidcProvider {
+		return &Cloudflare{}
+	})
+}
+
+type Cloudflare struct {
+	Addition
+}
+
+type Addition struct {
+	TeamDomain string `json:"team_domain" required:"true"`
+	PolicyAUD  string `json:"policy_aud" required:"true"`
+}


### PR DESCRIPTION
接入现有OAuth登入流程
- 添加cloudflare.go meta.go
- 添加handler.go处理和OAuth流程中有差异的部分
- 修改现有oauth.go，当提供商为cloudflare_access时，调用handler.go
- 添加go-oidc，用于JWT的读取和校验

需要在单点登入设置中配置
- cloudflare零信任的团队名或完整URL（team_domain）
- access的应用程序受众 (AUD) 标签（policy_aud）

绑定外部账户时会绑定当前通过access的账户