### PR TITLE
feat: 添加对 Server酱Turbo & Server酱³ 推送通道支持（SendKey）

### DIFF
--- a/utils/messageSender/all.go
+++ b/utils/messageSender/all.go
@@ -4,6 +4,8 @@ import (
 	_ "github.com/komari-monitor/komari/utils/messageSender/bark"
 	_ "github.com/komari-monitor/komari/utils/messageSender/email"
 	_ "github.com/komari-monitor/komari/utils/messageSender/empty"
+	_ "github.com/komari-monitor/komari/utils/messageSender/serverchan3"
+	_ "github.com/komari-monitor/komari/utils/messageSender/serverchanturbo"
 	_ "github.com/komari-monitor/komari/utils/messageSender/telegram"
 	_ "github.com/komari-monitor/komari/utils/messageSender/webhook"
 )

--- a/utils/messageSender/serverchan3/meta.go
+++ b/utils/messageSender/serverchan3/meta.go
@@ -1,0 +1,21 @@
+package serverchan3
+
+import (
+    "github.com/komari-monitor/komari/utils/messageSender/factory"
+)
+
+// Addition 为 Server酱³ 推送通道的配置项
+// 所有字段通过管理页面以 JSON 形式进行设置
+type Addition struct {
+    // APIURL 为接口完整地址，例如：https://<uid>.push.ft07.com/send/<sendkey>.send
+    APIURL string `json:"api_url" required:"true" help:"接口完整地址，例如 https://<uid>.push.ft07.com/send/<sendkey>.send；参考：https://sc3.ft07.com/"`
+    // Tags 为可选标签，使用 | 分割，例如：tag1|tag2|tag3
+    Tags   string `json:"tags" help:"可选标签，使用 | 分割，例如 tag1|tag2|tag3"`
+}
+
+// 注册 Server酱³ 推送通道到工厂
+func init() {
+    factory.RegisterMessageSender(func() factory.IMessageSender {
+        return &ServerChan3Sender{}
+    })
+}

--- a/utils/messageSender/serverchan3/serverchan3.go
+++ b/utils/messageSender/serverchan3/serverchan3.go
@@ -1,0 +1,105 @@
+package serverchan3
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/komari-monitor/komari/utils/messageSender/factory"
+)
+
+// ServerChan3Sender 为 Server酱³ 推送实现
+type ServerChan3Sender struct {
+	Addition
+}
+
+// GetName 返回推送通道名称
+func (s *ServerChan3Sender) GetName() string {
+	return "Server酱³"
+}
+
+// GetConfiguration 返回配置结构体指针
+func (s *ServerChan3Sender) GetConfiguration() factory.Configuration {
+	return &s.Addition
+}
+
+// Init 初始化（当前无需处理）
+func (s *ServerChan3Sender) Init() error { return nil }
+
+// Destroy 清理（当前无需处理）
+func (s *ServerChan3Sender) Destroy() error { return nil }
+
+// SendTextMessage 发送文本消息（携带标题）。
+// 简化为固定 JSON POST：内部仅组装 {"title": ..., "desp": ...}，不允许用户自定义请求体或内容类型。
+func (s *ServerChan3Sender) SendTextMessage(message, title string) error {
+	apiURL := strings.TrimSpace(s.Addition.APIURL)
+	if apiURL == "" {
+		return fmt.Errorf("未配置 Server酱³ 接口地址(api_url)")
+	}
+
+	// 简化校验：若标题与正文均为空则拒绝发送
+	finalTitle := strings.TrimSpace(title)
+	finalMessage := strings.TrimSpace(message)
+	if finalTitle == "" && finalMessage == "" {
+		return fmt.Errorf("serverchan3: 标题与正文均为空")
+	}
+
+	// 固定 JSON 载荷，包含 title、desp，并支持可选 tags（通过 | 分割）
+	payload := map[string]string{
+		"title": finalTitle,
+		"desp":  finalMessage,
+	}
+	if tagsStr := strings.TrimSpace(s.Addition.Tags); tagsStr != "" {
+		parts := strings.Split(tagsStr, "|")
+		var cleaned []string
+		for _, p := range parts {
+			t := strings.TrimSpace(p)
+			if t != "" {
+				cleaned = append(cleaned, t)
+			}
+		}
+		if len(cleaned) > 0 {
+			// Server酱³ 校验提示需要字符串，这里按 | 拼接为字符串
+			payload["tags"] = strings.Join(cleaned, "|")
+		}
+	}
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("组装 JSON 失败: %v", err)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("创建请求失败: %v", err)
+	}
+	// 固定设置 Content-Type
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("发送请求失败: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// 读取响应体用于错误信息打印
+		b, _ := io.ReadAll(resp.Body)
+		msg := strings.TrimSpace(string(b))
+		if msg == "" {
+			return fmt.Errorf("接口返回非 2xx 状态码: %d", resp.StatusCode)
+		}
+		return fmt.Errorf("接口返回非 2xx 状态码: %d，响应: %s", resp.StatusCode, msg)
+	}
+
+	return nil
+}
+
+// 之前的模板、表单解析与手动转义工具不再需要，简化实现
+
+// 确保实现 IMessageSender 接口
+var _ factory.IMessageSender = (*ServerChan3Sender)(nil)

--- a/utils/messageSender/serverchanturbo/meta.go
+++ b/utils/messageSender/serverchanturbo/meta.go
@@ -1,0 +1,25 @@
+package serverchanturbo
+
+import (
+    "github.com/komari-monitor/komari/utils/messageSender/factory"
+)
+
+// Addition 为 Server酱 Turbo 推送通道的配置项
+// 仅允许配置接口地址及可选的通道/隐藏IP/openid，固定以 JSON 发送
+type Addition struct {
+    // APIURL 为接口完整地址，例如：https://sctapi.ftqq.com/<sendkey>.send
+    APIURL  string `json:"api_url" required:"true" help:"接口完整地址，例如 https://sctapi.ftqq.com/<sendkey>.send；参考：https://sct.ftqq.com/"`
+    // Channel 为本次推送使用的消息通道，最多两个，多个用 | 隔开，例如：9|66
+    Channel string `json:"channel" help:"消息通道，可选，多个用 | 隔开，例如 9|66"`
+    // NoIP 是否隐藏调用 IP，填 1 则隐藏
+    NoIP    string `json:"noip" help:"是否隐藏调用IP，填 1 隐藏；为空则不隐藏"`
+    // OpenID 消息抄送 openid，测试号用 , 分隔；企业微信应用用 | 分隔
+    OpenID  string `json:"openid" help:"抄送 openid，测试号用 , 分隔；企业微信应用用 | 分隔"`
+}
+
+// 注册 Server酱 Turbo 推送通道到工厂
+func init() {
+    factory.RegisterMessageSender(func() factory.IMessageSender {
+        return &ServerChanTurboSender{}
+    })
+}

--- a/utils/messageSender/serverchanturbo/serverchanturbo.go
+++ b/utils/messageSender/serverchanturbo/serverchanturbo.go
@@ -1,0 +1,95 @@
+package serverchanturbo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/komari-monitor/komari/utils/messageSender/factory"
+)
+
+// ServerChanTurboSender 为 Server酱 Turbo 推送实现
+type ServerChanTurboSender struct {
+	Addition
+}
+
+// GetName 返回推送通道名称
+func (s *ServerChanTurboSender) GetName() string {
+	return "Server酱Turbo"
+}
+
+// GetConfiguration 返回配置结构体指针
+func (s *ServerChanTurboSender) GetConfiguration() factory.Configuration {
+	return &s.Addition
+}
+
+// Init 初始化（当前无需处理）
+func (s *ServerChanTurboSender) Init() error { return nil }
+
+// Destroy 清理（当前无需处理）
+func (s *ServerChanTurboSender) Destroy() error { return nil }
+
+// SendTextMessage 固定以 JSON 发送，仅组装 title 与 desp，支持可选 channel/noip/openid
+func (s *ServerChanTurboSender) SendTextMessage(message, title string) error {
+	apiURL := strings.TrimSpace(s.Addition.APIURL)
+	if apiURL == "" {
+		return fmt.Errorf("未配置 Server酱 Turbo 接口地址(api_url)")
+	}
+
+	finalTitle := strings.TrimSpace(title)
+	finalMessage := strings.TrimSpace(message)
+	if finalTitle == "" && finalMessage == "" {
+		return fmt.Errorf("serverchanturbo: 标题与正文均为空")
+	}
+
+	payload := map[string]interface{}{
+		"title": finalTitle,
+		"desp":  finalMessage,
+	}
+	if ch := strings.TrimSpace(s.Addition.Channel); ch != "" {
+		payload["channel"] = ch
+	}
+	if noip := strings.TrimSpace(s.Addition.NoIP); noip == "1" {
+		payload["noip"] = "1"
+	}
+	if openid := strings.TrimSpace(s.Addition.OpenID); openid != "" {
+		payload["openid"] = openid
+	}
+
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("serverchanturbo: 组装 JSON 失败: %v", err)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("serverchanturbo: 创建请求失败: %v", err)
+	}
+	// 使用 JSON 传递参数，需要设置 Content-Type
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("serverchanturbo: 发送请求失败: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		msg := strings.TrimSpace(string(b))
+		if msg == "" {
+			return fmt.Errorf("serverchanturbo: 接口返回非 2xx 状态码: %d", resp.StatusCode)
+		}
+		return fmt.Errorf("serverchanturbo: 接口返回非 2xx 状态码: %d，响应: %s", resp.StatusCode, msg)
+	}
+
+	return nil
+}
+
+// 确保实现 IMessageSender 接口
+var _ factory.IMessageSender = (*ServerChanTurboSender)(nil)


### PR DESCRIPTION
添加对 Server酱Turbo & Server酱³ 推送通道支持（SendKey）
本地测试通过。

配置

 Server酱Turbo（参考：https://sct.ftqq.com/）
api_url ：`https://sctapi.ftqq.com/<sendkey>.send`
通道一般为9、66，详情请参考官方文档
channel：9|66

 Server酱³（参考：https://sc3.ft07.com/）
api_url ：`https://<uid>.push.ft07.com/send/<sendkey>.send`



![Screenshot_20251103_223251_com tencent mm_edit_16](https://github.com/user-attachments/assets/c98971d1-3e77-4f69-8b12-c73d084256d8)
![Screenshot_20251103_223257_com ft07 serverchan ap](https://github.com/user-attachments/assets/0b986119-4f99-49d3-8ba3-d3af7395d994)
