### PR TITLE
Add html support for email

### DIFF
--- a/internal/messageSender/email/email.go
+++ b/internal/messageSender/email/email.go
@@ -168,13 +168,22 @@ func (e *EmailSender) SendTextMessage(message, title string) error {
 		return fmt.Errorf("failed to finalize body encoding: %w", err)
 	}
 
+	contentType := "text/plain; charset=UTF-8"
+	// 检测模板是否包含HTML
+	trimmedMsg := strings.TrimSpace(message)
+	if strings.Contains(strings.ToLower(trimmedMsg), "<html") ||
+		strings.Contains(strings.ToLower(trimmedMsg), "<!doctype") ||
+		(strings.Contains(trimmedMsg, "<div") && strings.Contains(trimmedMsg, "</div>")) {
+		contentType = "text/html; charset=UTF-8"
+	}
+
 	// Compose headers
 	headers := []string{
 		"To: " + strings.Join(rcptHeaderParts, ", "),
 		"From: " + senderHeader,
 		"Subject: " + encodedSubject,
 		"MIME-Version: 1.0",
-		"Content-Type: text/plain; charset=UTF-8",
+		"Content-Type: " + contentType,
 		"Content-Transfer-Encoding: quoted-printable",
 		"Date: " + time.Now().Format(time.RFC1123Z),
 		fmt.Sprintf("Message-ID: <%d@%s>", time.Now().UnixNano(), e.Addition.Host),


### PR DESCRIPTION
添加在Email对HTML的支持。
关联 #379。

原理：在SendTextMessage中，添加对模板的检测。如果模板中包含HTML元素，则设置`contentType = "text/html; charset=UTF-8" `

兼容性：未破坏原有代码，对过往配置保持兼容。
验证：在Actions编译的 linux amd64上测试通过。