### PR TITLE
docs: 新增社区版 Git 同步脚本（节点 IP 快照）

### DIFF
--- a/contrib/git-sync/README_zh.md
+++ b/contrib/git-sync/README_zh.md
@@ -1,0 +1,22 @@
+# Komari 节点 IP 同步到 Git（社区脚本）
+
+> 说明：这是社区提供的外部同步脚本，不是 Komari 内置核心功能。
+
+该方案会从 `komari.db` 的 `clients` 表导出节点 IP 快照，按定时任务自动提交到 Git 仓库。
+
+## 文件
+- `komari-git-sync.sh`
+- `komari-git-sync.env.example`
+- `komari-git-sync.service`
+- `komari-git-sync.timer`
+
+## 默认行为
+- 单向同步：服务器 -> Git
+- 默认每 1 小时执行一次（可在 timer 中调整）
+
+## 快速使用
+1. 安装脚本与 systemd 文件
+2. 编辑 `/etc/komari-git-sync.env`
+3. 启动 timer
+
+详见仓库内脚本注释。

--- a/contrib/git-sync/komari-git-sync.env.example
+++ b/contrib/git-sync/komari-git-sync.env.example
@@ -1,0 +1,17 @@
+# Git 仓库地址（建议 private）
+REPO_URL=https://github.com/<your-name>/<your-repo>.git
+
+# 分支名
+BRANCH=main
+
+# Komari sqlite 数据库路径
+KOMARI_DB=/data/komari-monitor/data/komari.db
+
+# 本地工作目录（会 clone 仓库到这里）
+WORKDIR=/data/komari-monitor/git-sync
+
+# 导出的快照文件名
+SNAPSHOT_FILE=nodes-ip.json
+
+# 日志路径
+SYNC_LOG=/var/log/komari-git-sync.log

--- a/contrib/git-sync/komari-git-sync.service
+++ b/contrib/git-sync/komari-git-sync.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Sync Komari node IP snapshot to Git
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/komari-git-sync.sh

--- a/contrib/git-sync/komari-git-sync.sh
+++ b/contrib/git-sync/komari-git-sync.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Komari 节点 IP 同步到 Git 的主脚本
+# 通过读取 komari.db 的 clients 表，生成 nodes-ip.json
+# 当文件变化时自动 commit + push
+
+ENV_FILE="/etc/komari-git-sync.env"
+[[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
+
+: "${KOMARI_DB:=/data/komari-monitor/data/komari.db}"
+: "${WORKDIR:=/data/komari-monitor/git-sync}"
+: "${BRANCH:=main}"
+: "${SNAPSHOT_FILE:=nodes-ip.json}"
+: "${SYNC_LOG:=/var/log/komari-git-sync.log}"
+
+log(){ echo "[$(date '+%F %T')] $*" | tee -a "$SYNC_LOG"; }
+
+if [[ -z "${REPO_URL:-}" ]]; then
+  log "REPO_URL is empty, skip"
+  exit 0
+fi
+
+if [[ ! -f "$KOMARI_DB" ]]; then
+  log "DB not found: $KOMARI_DB"
+  exit 1
+fi
+
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+
+if [[ ! -d .git ]]; then
+  log "clone repo: $REPO_URL"
+  git clone --branch "$BRANCH" "$REPO_URL" .
+fi
+
+git fetch origin "$BRANCH" || true
+git checkout "$BRANCH"
+git pull --rebase origin "$BRANCH" || true
+
+TMP=$(mktemp)
+sqlite3 -json "$KOMARI_DB" "select name, ipv4, ipv6, updated_at from clients where (ipv4 is not null and ipv4!='') or (ipv6 is not null and ipv6!='') order by name asc;" > "$TMP"
+
+cat > "$SNAPSHOT_FILE" <<JSON
+{
+  "generated_at": "$(date -Iseconds)",
+  "source": "komari.db",
+  "host": "$(hostname)",
+  "nodes": $(cat "$TMP")
+}
+JSON
+rm -f "$TMP"
+
+if git diff --quiet -- "$SNAPSHOT_FILE"; then
+  log "no changes"
+  exit 0
+fi
+
+git add "$SNAPSHOT_FILE"
+git commit -m "chore(komari): sync node ips $(date '+%F %T')"
+git push origin "$BRANCH"
+log "synced to git"

--- a/contrib/git-sync/komari-git-sync.timer
+++ b/contrib/git-sync/komari-git-sync.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Komari git sync every 1 hour (default)
+
+[Timer]
+OnBootSec=2min
+# 默认每 1 小时同步一次（可按需改成 15min / 30min / 6h 等）
+OnUnitActiveSec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## 变更说明
本 PR 新增一套**社区维护**的 Git 同步脚本，放在 `contrib/git-sync/` 目录，用于将 Komari 节点 IP 快照按定时任务同步到 Git 仓库。

> 说明：这不是 Komari 内置核心功能，而是可选部署方案。

## 主要特性
- 单向同步：服务器 -> Git
- 默认每 1 小时执行一次（用户可自行调整）
- 仅在数据变化时提交，避免无效 commit

## 新增文件
- `contrib/git-sync/komari-git-sync.sh`
- `contrib/git-sync/komari-git-sync.env.example`
- `contrib/git-sync/komari-git-sync.service`
- `contrib/git-sync/komari-git-sync.timer`
- `contrib/git-sync/README_zh.md`

## 使用场景
- 追踪 GCP 等动态 IP 变化
- 在团队内共享节点快照
- 做基础审计与回溯

## 仓库项目（可直接使用）
即使本 PR 尚未合并，也可以直接使用以下公共仓库：
- 公共项目仓库（脚本+中文教程）：
  - https://github.com/constansino/komari-git-sync

> 私有数据仓库不在此公开，避免泄露。

如果维护者希望，我可以在后续补一个英文 README（`README.md`）版本。
