### PR TITLE
fix: reset traffic cache when traffic drops

### DIFF
--- a/utils/notifier/traffic.go
+++ b/utils/notifier/traffic.go
@@ -85,9 +85,14 @@ func CheckTraffic() {
 		last, _ := trafficCache.Get(key)
 		lastStep, _ := last.(int)
 
+		// 修复：当检测到当前进度小于历史记录时，说明流量已重置，将基准归零
+		if curStep < lastStep {
+			lastStep = 0
+		}
+
 		if curStep > lastStep { // 只在进入新步进时提醒一次
 			trafficCache.SetDefault(key, curStep)
-
+		
 			msg := fmt.Sprintf("used %d%% (%s / %s), type=%s", curStep, humanBytes(used), humanBytes(c.TrafficLimit), strings.ToLower(c.TrafficLimitType))
 			// 发送通知（内部会检查 NotificationEnabled）
 			_ = messageSender.SendEvent(models.EventMessage{


### PR DESCRIPTION
修复当节点流量被清零重置时，内存中的告警进度缓存未同步清理，导致无法触发后续阈值通知的 Bug。