### PR TITLE
fix: prevent SSRF in theme download by blocking private/internal IPs

### DIFF
--- a/api/admin/theme.go
+++ b/api/admin/theme.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -291,9 +292,39 @@ func isValidThemeShort(short string) bool {
 }
 
 // downloadThemeFromURL 从URL下载主题文件
-func downloadThemeFromURL(url string) ([]byte, error) {
+// isPrivateIP checks if the resolved IP addresses are private/internal
+func isPrivateIP(host string) bool {
+	ips, err := net.LookupHost(host)
+	if err != nil {
+		return true // fail closed
+	}
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return true
+		}
+	}
+	return false
+}
+
+func downloadThemeFromURL(rawURL string) ([]byte, error) {
+	// SSRF protection: block requests to private/internal IPs
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %v", err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return nil, fmt.Errorf("only http and https schemes are allowed")
+	}
+	if isPrivateIP(parsedURL.Hostname()) {
+		return nil, fmt.Errorf("requests to private/internal addresses are not allowed")
+	}
+
 	// 发送HTTP GET请求
-	resp, err := http.Get(url)
+	resp, err := http.Get(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("下载主题文件失败: %v", err)
 	}


### PR DESCRIPTION
## Summary

Prevent SSRF in theme download/import/update endpoints by validating that URLs don't resolve to private or internal IP addresses.

## Problem

The `downloadThemeFromURL` function fetches arbitrary URLs without any SSRF protection:

```go
func downloadThemeFromURL(url string) ([]byte, error) {
    resp, err := http.Get(url)  // No IP validation
```

This function is called by three admin endpoints:
- `ImportTheme` — imports theme from user-supplied URL
- `UpdateTheme` — updates theme from stored or user-supplied URL
- Internal GitHub release downloads

An attacker with admin access (or via CSRF if no CSRF protection) can:
- Access cloud metadata: `{"url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"}` → leaks IAM credentials
- Scan internal network services
- Access internal admin panels and APIs

## Fix

Added `isPrivateIP()` validation in `downloadThemeFromURL` that:
1. Validates URL scheme (only http/https)
2. Resolves the hostname and checks all IPs against Go's built-in `IsLoopback()`, `IsPrivate()`, `IsLinkLocalUnicast()`, and `IsLinkLocalMulticast()` checks
3. Fails closed (blocks if DNS resolution fails)

## Impact

- **Type**: Server-Side Request Forgery (CWE-918)
- **Affected endpoints**: `POST /api/admin/theme/import`, `POST /api/admin/theme/update`
- **Risk**: Cloud credential theft, internal network scanning
- **OWASP**: A10:2021 — Server-Side Request Forgery