### PR TITLE
fix: 防止无返回文本的远程执行结果被后端拒绝而变成超时

### DIFF
--- a/api/client/task.go
+++ b/api/client/task.go
@@ -18,7 +18,7 @@ func TaskResult(c *gin.Context) {
 	}
 	var req struct {
 		TaskId     string    `json:"task_id" binding:"required"`
-		Result     string    `json:"result" binding:"required"`
+		Result     string    `json:"result"`
 		ExitCode   int       `json:"exit_code"`
 		FinishedAt time.Time `json:"finished_at" binding:"required"`
 	}


### PR DESCRIPTION
目前的逻辑要求 Result 必须有内容, 但如果执行无返回文本的命令, 比如说 `systemctl restart xxxx`, 由于 `binding:"required"` 就导致执行结果被拒绝接受, 显示为超时. 其实不需要一定要有返回文本吧?