### PR TITLE
feat: improve built-in cloudflared tunnel management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM debian:bookworm-slim
+FROM alpine:3.21
 
 WORKDIR /app
 
+# Docker buildx 会在构建时自动填充这些变量
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl tzdata \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates curl tzdata
 
 RUN set -eux; \
     case "${TARGETARCH}" in \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,24 @@
-FROM alpine:3.21
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
-# Docker buildx 会在构建时自动填充这些变量
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache tzdata
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) cloudflared_arch="amd64" ;; \
+      386) cloudflared_arch="386" ;; \
+      arm64) cloudflared_arch="arm64" ;; \
+      arm) cloudflared_arch="arm" ;; \
+      *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${cloudflared_arch}" -o /usr/local/bin/cloudflared; \
+    chmod +x /usr/local/bin/cloudflared
 
 COPY komari-${TARGETOS}-${TARGETARCH} /app/komari
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,6 @@ sudo ./install-komari.sh
 > [!NOTE]
 > You can also customize the initial username and password through the environment variables `ADMIN_USERNAME` and `ADMIN_PASSWORD`.
 
-> [!TIP]
-> The Docker image bundles `cloudflared`, so you can configure and start a Cloudflare Tunnel directly from the admin panel without installing `cloudflared` separately inside the container.
-
 ### 3. Binary File Deployment
 
 1. Visit Komari's [GitHub Release page](https://github.com/komari-monitor/komari/releases) to download the latest binary for your operating system.
@@ -77,38 +74,6 @@ sudo ./install-komari.sh
 
 > [!NOTE]
 > Ensure the binary has execute permissions (`chmod +x komari`). Data will be saved in the `data` folder in the running directory.
-
-> [!TIP]
-> For non-Docker deployments, install `cloudflared` manually or point `KOMARI_CLOUDFLARED_BIN` to the `cloudflared` binary path before using the built-in Cloudflare Tunnel controls.
-
-## Cloudflare Tunnel
-
-Komari includes an admin-facing Reverse Proxy page at `/admin/settings/reverse-proxy` for managing `cloudflared`.
-
-You can:
-
-- Save a Cloudflare Tunnel token securely
-- Start and stop `cloudflared` from the settings page
-- Check whether `cloudflared` is installed
-- View runtime status, recent logs, and error messages
-- Restore `cloudflared` automatically after restart when a token is stored or passed by environment variable
-
-### Environment Variables
-
-- `KOMARI_CLOUDFLARED_TOKEN`
-  Provide a Cloudflare Tunnel token at startup. Komari will persist it and try to auto-start `cloudflared`.
-- `KOMARI_CLOUDFLARED_BIN`
-  Optional custom path to the `cloudflared` binary, mainly for non-Docker deployments.
-- `KOMARI_SECRET_KEY`
-  Optional secret used to encrypt stored Cloudflare Tunnel tokens. If unset, Komari creates a local key under `./data/secret.key`.
-
-### Security Notes
-
-- Komari starts `cloudflared` with the token passed through the process environment instead of CLI arguments.
-- The settings API never returns the raw token to the browser. The frontend only receives whether a token is stored.
-- Stopping `cloudflared` requires re-validating the current admin identity:
-  - current password when password login is enabled
-  - exact confirmation text `STOP CLOUDFLARED` when password login is disabled
 
 ### Manual Build
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ sudo ./install-komari.sh
 > [!NOTE]
 > You can also customize the initial username and password through the environment variables `ADMIN_USERNAME` and `ADMIN_PASSWORD`.
 
+> [!TIP]
+> The Docker image bundles `cloudflared`, so you can configure and start a Cloudflare Tunnel directly from the admin panel without installing `cloudflared` separately inside the container.
+
 ### 3. Binary File Deployment
 
 1. Visit Komari's [GitHub Release page](https://github.com/komari-monitor/komari/releases) to download the latest binary for your operating system.
@@ -74,6 +77,38 @@ sudo ./install-komari.sh
 
 > [!NOTE]
 > Ensure the binary has execute permissions (`chmod +x komari`). Data will be saved in the `data` folder in the running directory.
+
+> [!TIP]
+> For non-Docker deployments, install `cloudflared` manually or point `KOMARI_CLOUDFLARED_BIN` to the `cloudflared` binary path before using the built-in Cloudflare Tunnel controls.
+
+## Cloudflare Tunnel
+
+Komari includes an admin-facing Reverse Proxy page at `/admin/settings/reverse-proxy` for managing `cloudflared`.
+
+You can:
+
+- Save a Cloudflare Tunnel token securely
+- Start and stop `cloudflared` from the settings page
+- Check whether `cloudflared` is installed
+- View runtime status, recent logs, and error messages
+- Restore `cloudflared` automatically after restart when a token is stored or passed by environment variable
+
+### Environment Variables
+
+- `KOMARI_CLOUDFLARED_TOKEN`
+  Provide a Cloudflare Tunnel token at startup. Komari will persist it and try to auto-start `cloudflared`.
+- `KOMARI_CLOUDFLARED_BIN`
+  Optional custom path to the `cloudflared` binary, mainly for non-Docker deployments.
+- `KOMARI_SECRET_KEY`
+  Optional secret used to encrypt stored Cloudflare Tunnel tokens. If unset, Komari creates a local key under `./data/secret.key`.
+
+### Security Notes
+
+- Komari starts `cloudflared` with the token passed through the process environment instead of CLI arguments.
+- The settings API never returns the raw token to the browser. The frontend only receives whether a token is stored.
+- Stopping `cloudflared` requires re-validating the current admin identity:
+  - current password when password login is enabled
+  - exact confirmation text `STOP CLOUDFLARED` when password login is disabled
 
 ### Manual Build
 

--- a/api/admin/cloudflared.go
+++ b/api/admin/cloudflared.go
@@ -18,29 +18,6 @@ func GetCloudflaredStatus(c *gin.Context) {
 	api.RespondSuccess(c, cloudflared.Status())
 }
 
-func SaveCloudflaredToken(c *gin.Context) {
-	var req struct {
-		Token string `json:"token"`
-	}
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		api.RespondError(c, http.StatusBadRequest, "Invalid request body: "+err.Error())
-		return
-	}
-	if strings.TrimSpace(req.Token) == "" {
-		api.RespondError(c, http.StatusBadRequest, "Cloudflare Tunnel token cannot be empty")
-		return
-	}
-	if err := cloudflared.SaveToken(req.Token); err != nil {
-		api.RespondError(c, http.StatusInternalServerError, "Failed to save Cloudflare Tunnel token: "+err.Error())
-		return
-	}
-	if uuid, ok := c.Get("uuid"); ok {
-		auditlog.Log(c.ClientIP(), uuid.(string), "saved cloudflared tunnel token", "warn")
-	}
-	api.RespondSuccess(c, cloudflared.Status())
-}
-
 func StartCloudflared(c *gin.Context) {
 	var req struct {
 		Token string `json:"token"`

--- a/api/admin/cloudflared.go
+++ b/api/admin/cloudflared.go
@@ -1,0 +1,127 @@
+package admin
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/komari-monitor/komari/api"
+	"github.com/komari-monitor/komari/config"
+	"github.com/komari-monitor/komari/database/accounts"
+	"github.com/komari-monitor/komari/database/auditlog"
+	"github.com/komari-monitor/komari/utils/cloudflared"
+)
+
+const cloudflaredStopConfirmText = "STOP CLOUDFLARED"
+
+func GetCloudflaredStatus(c *gin.Context) {
+	api.RespondSuccess(c, cloudflared.Status())
+}
+
+func SaveCloudflaredToken(c *gin.Context) {
+	var req struct {
+		Token string `json:"token"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		api.RespondError(c, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Token) == "" {
+		api.RespondError(c, http.StatusBadRequest, "Cloudflare Tunnel token cannot be empty")
+		return
+	}
+	if err := cloudflared.SaveToken(req.Token); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, "Failed to save Cloudflare Tunnel token: "+err.Error())
+		return
+	}
+	if uuid, ok := c.Get("uuid"); ok {
+		auditlog.Log(c.ClientIP(), uuid.(string), "saved cloudflared tunnel token", "warn")
+	}
+	api.RespondSuccess(c, cloudflared.Status())
+}
+
+func StartCloudflared(c *gin.Context) {
+	var req struct {
+		Token string `json:"token"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+		api.RespondError(c, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+
+	token := strings.TrimSpace(req.Token)
+	if token != "" {
+		if err := cloudflared.SaveToken(token); err != nil {
+			api.RespondError(c, http.StatusInternalServerError, "Failed to save Cloudflare Tunnel token: "+err.Error())
+			return
+		}
+	}
+	if err := cloudflared.Start(token); err != nil {
+		api.RespondError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	if uuid, ok := c.Get("uuid"); ok {
+		auditlog.Log(c.ClientIP(), uuid.(string), "started cloudflared tunnel", "warn")
+	}
+	api.RespondSuccess(c, cloudflared.Status())
+}
+
+func StopCloudflared(c *gin.Context) {
+	var req struct {
+		CurrentPassword string `json:"current_password"`
+		ConfirmText     string `json:"confirm_text"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+		api.RespondError(c, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+
+	disablePasswordLogin, _ := config.GetAs[bool](config.DisablePasswordLoginKey, false)
+	if !disablePasswordLogin {
+		rawUUID, exists := c.Get("uuid")
+		if !exists {
+			api.RespondError(c, http.StatusUnauthorized, "Unauthorized.")
+			return
+		}
+
+		user, err := accounts.GetUserByUUID(rawUUID.(string))
+		if err != nil {
+			api.RespondError(c, http.StatusUnauthorized, "Failed to verify current user")
+			return
+		}
+		if strings.TrimSpace(req.CurrentPassword) == "" {
+			api.RespondError(c, http.StatusBadRequest, "Current password is required")
+			return
+		}
+		if _, ok := accounts.CheckPassword(user.Username, req.CurrentPassword); !ok {
+			api.RespondError(c, http.StatusUnauthorized, "Current password is incorrect")
+			return
+		}
+	} else if strings.TrimSpace(req.ConfirmText) != cloudflaredStopConfirmText {
+		api.RespondError(c, http.StatusBadRequest, "Type STOP CLOUDFLARED to confirm stopping cloudflared")
+		return
+	}
+
+	if err := cloudflared.Stop(); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, "Failed to stop cloudflared: "+err.Error())
+		return
+	}
+	if uuid, ok := c.Get("uuid"); ok {
+		auditlog.Log(c.ClientIP(), uuid.(string), "stopped cloudflared tunnel", "warn")
+	}
+	api.RespondSuccess(c, cloudflared.Status())
+}
+
+func RemoveCloudflaredToken(c *gin.Context) {
+	if err := cloudflared.RemoveToken(); err != nil {
+		api.RespondError(c, http.StatusBadRequest, "Failed to remove Cloudflare Tunnel token: "+err.Error())
+		return
+	}
+	if uuid, ok := c.Get("uuid"); ok {
+		auditlog.Log(c.ClientIP(), uuid.(string), "removed cloudflared tunnel token", "warn")
+	}
+	api.RespondSuccess(c, cloudflared.Status())
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -127,11 +126,8 @@ func RunServer() {
 
 	})
 	// 初始化 cloudflared
-	if strings.ToLower(GetEnv("KOMARI_ENABLE_CLOUDFLARED", "false")) == "true" {
-		err := cloudflared.RunCloudflared() // 阻塞，确保cloudflared跑起来
-		if err != nil {
-			log.Fatalf("Failed to run cloudflared: %v", err)
-		}
+	if err := cloudflared.AutoStart(GetEnv("KOMARI_CLOUDFLARED_TOKEN", "")); err != nil {
+		log.Printf("failed to auto start cloudflared: %v", err)
 	}
 
 	r := gin.New()
@@ -251,6 +247,11 @@ func RunServer() {
 			settingsGroup.GET("/oidc", admin.GetOidcProvider)
 			settingsGroup.POST("/message-sender", admin.SetMessageSenderProvider)
 			settingsGroup.GET("/message-sender", admin.GetMessageSenderProvider)
+			settingsGroup.GET("/cloudflared", admin.GetCloudflaredStatus)
+			settingsGroup.POST("/cloudflared/token", admin.SaveCloudflaredToken)
+			settingsGroup.POST("/cloudflared/start", admin.StartCloudflared)
+			settingsGroup.POST("/cloudflared/stop", admin.StopCloudflared)
+			settingsGroup.POST("/cloudflared/remove-token", admin.RemoveCloudflaredToken)
 		}
 		// themes
 		themeGroup := adminAuthrized.Group("/theme")
@@ -425,10 +426,10 @@ func DoScheduledWork() {
 
 func OnShutdown() {
 	auditlog.Log("", "", "server is shutting down", "info")
-	cloudflared.Kill()
+	cloudflared.Shutdown()
 }
 
 func OnFatal(err error) {
 	auditlog.Log("", "", "server encountered a fatal error: "+err.Error(), "error")
-	cloudflared.Kill()
+	cloudflared.Shutdown()
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -248,7 +248,6 @@ func RunServer() {
 			settingsGroup.POST("/message-sender", admin.SetMessageSenderProvider)
 			settingsGroup.GET("/message-sender", admin.GetMessageSenderProvider)
 			settingsGroup.GET("/cloudflared", admin.GetCloudflaredStatus)
-			settingsGroup.POST("/cloudflared/token", admin.SaveCloudflaredToken)
 			settingsGroup.POST("/cloudflared/start", admin.StartCloudflared)
 			settingsGroup.POST("/cloudflared/stop", admin.StopCloudflared)
 			settingsGroup.POST("/cloudflared/remove-token", admin.RemoveCloudflaredToken)

--- a/config/legacy.go
+++ b/config/legacy.go
@@ -3,39 +3,45 @@ package config
 import "time"
 
 type Legacy struct {
-	ID                         uint    `json:"id,omitempty"`
-	Sitename                   string  `json:"sitename" default:"Komari"`
-	Description                string  `json:"description" default:"A simple server monitor tool."`
-	AllowCors                  bool    `json:"allow_cors" default:"false"`
-	Theme                      string  `json:"theme" default:"default"`
-	PrivateSite                bool    `json:"private_site" default:"false"`
-	ApiKey                     string  `json:"api_key" default:""`
-	AutoDiscoveryKey           string  `json:"auto_discovery_key" default:""`
-	ScriptDomain               string  `json:"script_domain" default:""`
-	SendIpAddrToGuest          bool    `json:"send_ip_addr_to_guest" default:"false"`
-	EulaAccepted               bool    `json:"eula_accepted" default:"false"`
-	BaseScriptsURLKey          string  `json:"base_scripts_url" default:""`
-	GeoIpEnabled               bool    `json:"geo_ip_enabled" default:"true"`
-	GeoIpProvider              string  `json:"geo_ip_provider" default:"ipinfo"`
-	NezhaCompatEnabled         bool    `json:"nezha_compat_enabled" default:"false"`
-	NezhaCompatListen          string  `json:"nezha_compat_listen" default:""`
-	OAuthEnabled               bool    `json:"o_auth_enabled" default:"false"`
-	OAuthProvider              string  `json:"o_auth_provider" default:"github"`
-	DisablePasswordLogin       bool    `json:"disable_password_login" default:"false"`
-	CloudflareTunnelToken      string  `json:"cloudflare_tunnel_token" default:""`
-	CustomHead                 string  `json:"custom_head" default:""`
-	CustomBody                 string  `json:"custom_body" default:""`
-	NotificationEnabled        bool    `json:"notification_enabled" default:"true"`
+	ID                uint   `json:"id,omitempty"`                                        // 1
+	Sitename          string `json:"sitename" default:"Komari"`                           // 站点名称，默认 "Komari"
+	Description       string `json:"description" default:"A simple server monitor tool."` // 站点描述
+	AllowCors         bool   `json:"allow_cors" default:"false"`                          // 是否允许跨域，默认 false
+	Theme             string `json:"theme" default:"default"`                             // 主题名称，默认 'default'
+	PrivateSite       bool   `json:"private_site" default:"false"`                        // 是否为私有站点，默认 false
+	ApiKey            string `json:"api_key" default:""`                                  // API 密钥，默认空字符串
+	AutoDiscoveryKey  string `json:"auto_discovery_key" default:""`                       // 自动发现密钥
+	ScriptDomain      string `json:"script_domain" default:""`                            // 自定义脚本域名
+	SendIpAddrToGuest bool   `json:"send_ip_addr_to_guest" default:"false"`               // 是否向访客页面发送 IP 地址，默认 false
+	EulaAccepted      bool   `json:"eula_accepted" default:"false"`
+	BaseScriptsURLKey string `json:"base_scripts_url" default:""`
+	// GeoIP 配置
+	GeoIpEnabled  bool   `json:"geo_ip_enabled" default:"true"`
+	GeoIpProvider string `json:"geo_ip_provider" default:"ipinfo"` // empty, mmdb, ip-api, geojs
+	// Nezha 兼容（Agent gRPC）
+	NezhaCompatEnabled bool   `json:"nezha_compat_enabled" default:"false"`
+	NezhaCompatListen  string `json:"nezha_compat_listen" default:""` // 例如 0.0.0.0:5555
+	// OAuth 配置
+	OAuthEnabled          bool   `json:"o_auth_enabled" default:"false"`
+	OAuthProvider         string `json:"o_auth_provider" default:"github"`
+	DisablePasswordLogin  bool   `json:"disable_password_login" default:"false"`
+	CloudflareTunnelToken string `json:"cloudflare_tunnel_token" default:""`
+	// 自定义美化
+	CustomHead string `json:"custom_head" default:""`
+	CustomBody string `json:"custom_body" default:""`
+	// 通知
+	NotificationEnabled        bool    `json:"notification_enabled" default:"true"` // 通知总开关
 	NotificationMethod         string  `json:"notification_method" default:"none"`
 	NotificationTemplate       string  `json:"notification_template" default:"{{emoji}}{{emoji}}{{emoji}}\nEvent: {{event}}\nClients: {{client}}\nMessage: {{message}}\nTime: {{time}}"`
-	ExpireNotificationEnabled  bool    `json:"expire_notification_enabled" default:"true"`
-	ExpireNotificationLeadDays int     `json:"expire_notification_lead_days" default:"7"`
-	LoginNotification          bool    `json:"login_notification" default:"true"`
-	TrafficLimitPercentage     float64 `json:"traffic_limit_percentage" default:"80.00"`
-	RecordEnabled              bool    `json:"record_enabled" default:"true"`
-	RecordPreserveTime         int     `json:"record_preserve_time" default:"720"`
-	PingRecordPreserveTime     int     `json:"ping_record_preserve_time" default:"24"`
-	UpdatedAt                  time.Time
+	ExpireNotificationEnabled  bool    `json:"expire_notification_enabled" default:"true"` // 是否启用过期通知
+	ExpireNotificationLeadDays int     `json:"expire_notification_lead_days" default:"7"`  // 过期前多少天通知，默认7天
+	LoginNotification          bool    `json:"login_notification" default:"true"`          // 登录通知
+	TrafficLimitPercentage     float64 `json:"traffic_limit_percentage" default:"80.00"`   // 流量限制百分比，默认80.00%
+	// Record
+	RecordEnabled          bool `json:"record_enabled" default:"true"`          // 是否启用记录功能
+	RecordPreserveTime     int  `json:"record_preserve_time" default:"720"`     // 记录保留时间，单位小时，默认30天
+	PingRecordPreserveTime int  `json:"ping_record_preserve_time" default:"24"` // Ping 记录保留时间，单位小时，默认1天
+	UpdatedAt              time.Time
 }
 
 const (
@@ -76,3 +82,52 @@ const (
 func (Legacy) TableName() string {
 	return "configs"
 }
+
+// Decrepted
+/*
+func Update(cst map[string]interface{}) error {
+	oldConfig, _ := GetManyAs[Legacy]()
+	// Proceed with update
+	cst["updated_at"] = time.Now().Unix()
+	delete(cst, "created_at")
+	delete(cst, "CreatedAt")
+
+	// 至少有一种登录方式启用
+	newDisablePasswordLogin := oldConfig.DisablePasswordLogin
+	newOAuthEnabled := oldConfig.OAuthEnabled
+	if val, exists := cst["disable_password_login"]; exists {
+		newDisablePasswordLogin = val.(bool)
+	}
+	if val, exists := cst["o_auth_enabled"]; exists {
+		newOAuthEnabled = val.(bool)
+	}
+	if newDisablePasswordLogin && !newOAuthEnabled {
+		return errors.New("at least one login method must be enabled (password/oauth)")
+	}
+	// 没绑定账号也不能禁用
+	if newDisablePasswordLogin {
+		usr := &models.User{}
+		if err := Db.Model(&models.User{}).First(usr).Error; err != nil {
+			return errors.Join(err, errors.New("failed to retrieve user"))
+		}
+		if usr.SSOID == "" {
+			return errors.New("cannot disable password login when no SSO-bound account exists")
+		}
+	}
+	err := Db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.Config{}).Where("id = ?", oldConfig.ID).Updates(cst).Error; err != nil {
+			return errors.Join(err, errors.New("failed to update configuration"))
+		}
+		newConfig := &models.Config{}
+		if err := tx.Where("id = ?", oldConfig.ID).First(newConfig).Error; err != nil {
+			return errors.Join(err, errors.New("failed to retrieve updated configuration"))
+		}
+		//publishEvent(oldConfig, *newConfig)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+*/

--- a/config/legacy.go
+++ b/config/legacy.go
@@ -3,44 +3,39 @@ package config
 import "time"
 
 type Legacy struct {
-	ID                uint   `json:"id,omitempty"`                                        // 1
-	Sitename          string `json:"sitename" default:"Komari"`                           // 站点名称，默认 "Komari"
-	Description       string `json:"description" default:"A simple server monitor tool."` // 站点描述
-	AllowCors         bool   `json:"allow_cors" default:"false"`                          // 是否允许跨域，默认 false
-	Theme             string `json:"theme" default:"default"`                             // 主题名称，默认 'default'
-	PrivateSite       bool   `json:"private_site" default:"false"`                        // 是否为私有站点，默认 false
-	ApiKey            string `json:"api_key" default:""`                                  // API 密钥，默认空字符串
-	AutoDiscoveryKey  string `json:"auto_discovery_key" default:""`                       // 自动发现密钥
-	ScriptDomain      string `json:"script_domain" default:""`                            // 自定义脚本域名
-	SendIpAddrToGuest bool   `json:"send_ip_addr_to_guest" default:"false"`               // 是否向访客页面发送 IP 地址，默认 false
-	EulaAccepted      bool   `json:"eula_accepted" default:"false"`
-	BaseScriptsURLKey string `json:"base_scripts_url" default:""`
-	// GeoIP 配置
-	GeoIpEnabled  bool   `json:"geo_ip_enabled" default:"true"`
-	GeoIpProvider string `json:"geo_ip_provider" default:"ipinfo"` // empty, mmdb, ip-api, geojs
-	// Nezha 兼容（Agent gRPC）
-	NezhaCompatEnabled bool   `json:"nezha_compat_enabled" default:"false"`
-	NezhaCompatListen  string `json:"nezha_compat_listen" default:""` // 例如 0.0.0.0:5555
-	// OAuth 配置
-	OAuthEnabled         bool   `json:"o_auth_enabled" default:"false"`
-	OAuthProvider        string `json:"o_auth_provider" default:"github"`
-	DisablePasswordLogin bool   `json:"disable_password_login" default:"false"`
-	// 自定义美化
-	CustomHead string `json:"custom_head" default:""`
-	CustomBody string `json:"custom_body" default:""`
-	// 通知
-	NotificationEnabled        bool    `json:"notification_enabled" default:"true"` // 通知总开关
+	ID                         uint    `json:"id,omitempty"`
+	Sitename                   string  `json:"sitename" default:"Komari"`
+	Description                string  `json:"description" default:"A simple server monitor tool."`
+	AllowCors                  bool    `json:"allow_cors" default:"false"`
+	Theme                      string  `json:"theme" default:"default"`
+	PrivateSite                bool    `json:"private_site" default:"false"`
+	ApiKey                     string  `json:"api_key" default:""`
+	AutoDiscoveryKey           string  `json:"auto_discovery_key" default:""`
+	ScriptDomain               string  `json:"script_domain" default:""`
+	SendIpAddrToGuest          bool    `json:"send_ip_addr_to_guest" default:"false"`
+	EulaAccepted               bool    `json:"eula_accepted" default:"false"`
+	BaseScriptsURLKey          string  `json:"base_scripts_url" default:""`
+	GeoIpEnabled               bool    `json:"geo_ip_enabled" default:"true"`
+	GeoIpProvider              string  `json:"geo_ip_provider" default:"ipinfo"`
+	NezhaCompatEnabled         bool    `json:"nezha_compat_enabled" default:"false"`
+	NezhaCompatListen          string  `json:"nezha_compat_listen" default:""`
+	OAuthEnabled               bool    `json:"o_auth_enabled" default:"false"`
+	OAuthProvider              string  `json:"o_auth_provider" default:"github"`
+	DisablePasswordLogin       bool    `json:"disable_password_login" default:"false"`
+	CloudflareTunnelToken      string  `json:"cloudflare_tunnel_token" default:""`
+	CustomHead                 string  `json:"custom_head" default:""`
+	CustomBody                 string  `json:"custom_body" default:""`
+	NotificationEnabled        bool    `json:"notification_enabled" default:"true"`
 	NotificationMethod         string  `json:"notification_method" default:"none"`
 	NotificationTemplate       string  `json:"notification_template" default:"{{emoji}}{{emoji}}{{emoji}}\nEvent: {{event}}\nClients: {{client}}\nMessage: {{message}}\nTime: {{time}}"`
-	ExpireNotificationEnabled  bool    `json:"expire_notification_enabled" default:"true"` // 是否启用过期通知
-	ExpireNotificationLeadDays int     `json:"expire_notification_lead_days" default:"7"`  // 过期前多少天通知，默认7天
-	LoginNotification          bool    `json:"login_notification" default:"true"`          // 登录通知
-	TrafficLimitPercentage     float64 `json:"traffic_limit_percentage" default:"80.00"`   // 流量限制百分比，默认80.00%
-	// Record
-	RecordEnabled          bool `json:"record_enabled" default:"true"`          // 是否启用记录功能
-	RecordPreserveTime     int  `json:"record_preserve_time" default:"720"`     // 记录保留时间，单位小时，默认30天
-	PingRecordPreserveTime int  `json:"ping_record_preserve_time" default:"24"` // Ping 记录保留时间，单位小时，默认1天
-	UpdatedAt              time.Time
+	ExpireNotificationEnabled  bool    `json:"expire_notification_enabled" default:"true"`
+	ExpireNotificationLeadDays int     `json:"expire_notification_lead_days" default:"7"`
+	LoginNotification          bool    `json:"login_notification" default:"true"`
+	TrafficLimitPercentage     float64 `json:"traffic_limit_percentage" default:"80.00"`
+	RecordEnabled              bool    `json:"record_enabled" default:"true"`
+	RecordPreserveTime         int     `json:"record_preserve_time" default:"720"`
+	PingRecordPreserveTime     int     `json:"ping_record_preserve_time" default:"24"`
+	UpdatedAt                  time.Time
 }
 
 const (
@@ -62,6 +57,7 @@ const (
 	OAuthEnabledKey               = "o_auth_enabled"
 	OAuthProviderKey              = "o_auth_provider"
 	DisablePasswordLoginKey       = "disable_password_login"
+	CloudflareTunnelTokenKey      = "cloudflare_tunnel_token"
 	CustomHeadKey                 = "custom_head"
 	CustomBodyKey                 = "custom_body"
 	NotificationEnabledKey        = "notification_enabled"
@@ -80,52 +76,3 @@ const (
 func (Legacy) TableName() string {
 	return "configs"
 }
-
-// Decrepted
-/*
-func Update(cst map[string]interface{}) error {
-	oldConfig, _ := GetManyAs[Legacy]()
-	// Proceed with update
-	cst["updated_at"] = time.Now().Unix()
-	delete(cst, "created_at")
-	delete(cst, "CreatedAt")
-
-	// 至少有一种登录方式启用
-	newDisablePasswordLogin := oldConfig.DisablePasswordLogin
-	newOAuthEnabled := oldConfig.OAuthEnabled
-	if val, exists := cst["disable_password_login"]; exists {
-		newDisablePasswordLogin = val.(bool)
-	}
-	if val, exists := cst["o_auth_enabled"]; exists {
-		newOAuthEnabled = val.(bool)
-	}
-	if newDisablePasswordLogin && !newOAuthEnabled {
-		return errors.New("at least one login method must be enabled (password/oauth)")
-	}
-	// 没绑定账号也不能禁用
-	if newDisablePasswordLogin {
-		usr := &models.User{}
-		if err := Db.Model(&models.User{}).First(usr).Error; err != nil {
-			return errors.Join(err, errors.New("failed to retrieve user"))
-		}
-		if usr.SSOID == "" {
-			return errors.New("cannot disable password login when no SSO-bound account exists")
-		}
-	}
-	err := Db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(&models.Config{}).Where("id = ?", oldConfig.ID).Updates(cst).Error; err != nil {
-			return errors.Join(err, errors.New("failed to update configuration"))
-		}
-		newConfig := &models.Config{}
-		if err := tx.Where("id = ?", oldConfig.ID).First(newConfig).Error; err != nil {
-			return errors.Join(err, errors.New("failed to retrieve updated configuration"))
-		}
-		//publishEvent(oldConfig, *newConfig)
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-*/

--- a/utils/cloudflared/cloudflared.go
+++ b/utils/cloudflared/cloudflared.go
@@ -2,105 +2,153 @@ package cloudflared
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/komari-monitor/komari/config"
+	"github.com/komari-monitor/komari/utils/secureconfig"
 )
 
-func downloadCloudflared(downloadURL, filePath string) error {
-	log.Println("downloading cloudflared...")
-	resp, err := http.Get(downloadURL)
+type RuntimeStatus struct {
+	Installed       bool     `json:"installed"`
+	Running         bool     `json:"running"`
+	Message         string   `json:"message"`
+	ErrorMessage    string   `json:"errorMessage"`
+	Logs            []string `json:"logs"`
+	PID             int      `json:"pid,omitempty"`
+	BinaryPath      string   `json:"binaryPath,omitempty"`
+	TokenStored     bool     `json:"tokenStored"`
+	EnvTokenPresent bool     `json:"envTokenPresent"`
+}
+
+type manager struct {
+	mu            sync.RWMutex
+	cmd           *exec.Cmd
+	done          chan struct{}
+	running       bool
+	stopRequested bool
+	message       string
+	errorMessage  string
+	logs          []string
+	maxLogLines   int
+}
+
+var defaultManager = &manager{
+	maxLogLines: 80,
+	message:     "cloudflared is not running",
+}
+
+func Status() RuntimeStatus {
+	return defaultManager.status()
+}
+
+func Start(token string) error {
+	return defaultManager.start(token)
+}
+
+func Stop() error {
+	return defaultManager.stop()
+}
+
+func Shutdown() {
+	if err := defaultManager.stop(); err != nil {
+		log.Printf("failed to stop cloudflared: %v", err)
+	}
+}
+
+func SaveToken(token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return config.Set(config.CloudflareTunnelTokenKey, "")
+	}
+
+	encrypted, err := secureconfig.EncryptString(token)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-	out, err := os.Create(filePath)
-	if err != nil {
-		return err
+
+	return config.Set(config.CloudflareTunnelTokenKey, encrypted)
+}
+
+func RemoveToken() error {
+	if defaultManager.status().Running {
+		return errors.New("stop cloudflared before removing the token")
 	}
-	_, err = io.Copy(out, resp.Body)
-	closeErr := out.Close() // 先关闭文件
-	if err != nil {
-		return err
+	return config.Set(config.CloudflareTunnelTokenKey, "")
+}
+
+func LoadToken() (token string, err error) {
+	if envToken := strings.TrimSpace(os.Getenv("KOMARI_CLOUDFLARED_TOKEN")); envToken != "" {
+		return envToken, nil
 	}
-	if closeErr != nil {
-		return closeErr
-	}
-	if runtime.GOOS != "windows" {
-		err = os.Chmod(filePath, 0755)
+
+	return loadStoredToken()
+}
+
+func AutoStart(envToken string) error {
+	token := strings.TrimSpace(envToken)
+	if token == "" {
+		var err error
+		token, err = LoadToken()
 		if err != nil {
 			return err
 		}
+	} else {
+		if err := SaveToken(token); err != nil {
+			return err
+		}
+		log.Println("[cloudflared] using token from KOMARI_CLOUDFLARED_TOKEN")
 	}
+
+	if token == "" {
+		return nil
+	}
+
+	if err := Start(token); err != nil {
+		defaultManager.setError(err.Error())
+		return err
+	}
+
 	return nil
 }
 
-var cloudflaredCmd *exec.Cmd
+func (m *manager) start(token string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-func RunCloudflared() error {
-	var (
-		downloadURL string
-		fileName    = "cloudflared"
-	)
-	if _, err := os.Stat("data"); os.IsNotExist(err) {
-		os.Mkdir("data", 0755)
+	if m.running {
+		return errors.New("cloudflared is already running")
 	}
 
-	switch runtime.GOOS {
-	case "windows":
-		fileName = "cloudflared.exe"
-		switch runtime.GOARCH {
-		case "amd64":
-			downloadURL = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-amd64.exe"
-		case "386":
-			downloadURL = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-386.exe"
-		default:
-			return fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
-		}
-	case "linux":
-		switch runtime.GOARCH {
-		case "amd64":
-			downloadURL = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64"
-		case "386":
-			downloadURL = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-386"
-		case "arm":
-			downloadURL = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm"
-		case "arm64":
-			downloadURL = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64"
-		default:
-			return fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
-		}
-	case "darwin":
-		switch runtime.GOARCH {
-		case "amd64":
-			downloadURL = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-amd64.tgz"
-		case "arm64":
-			downloadURL = "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-arm64.tgz"
-		default:
-			return fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
-		}
-	default:
-		return fmt.Errorf("unsupported os: %s", runtime.GOOS)
-	}
-
-	filePath := "data/" + fileName
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		err := downloadCloudflared(downloadURL, filePath)
+	if strings.TrimSpace(token) == "" {
+		var err error
+		token, err = LoadToken()
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to load Cloudflare Tunnel token: %w", err)
 		}
 	}
+	if strings.TrimSpace(token) == "" {
+		return errors.New("cloudflare tunnel token is not configured")
+	}
 
-	args := []string{"tunnel", "--no-autoupdate", "run", "--token"}
-	token := os.Getenv("KOMARI_CLOUDFLARED_TOKEN")
-	args = append(args, token)
+	binaryPath, installed := resolveBinaryPath()
+	if !installed {
+		return errors.New("cloudflared is not installed; install it manually or use the Docker image with built-in cloudflared")
+	}
 
-	cmd := exec.Command(filePath, args...)
-	cloudflaredCmd = cmd
+	cmd := exec.Command(binaryPath, "tunnel", "--no-autoupdate", "run")
+	cmd.Env = append(os.Environ(), "TUNNEL_TOKEN="+token)
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
@@ -109,41 +157,230 @@ func RunCloudflared() error {
 	if err != nil {
 		return err
 	}
+
 	if err := cmd.Start(); err != nil {
 		return err
 	}
-	go func() {
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			log.Printf("[cloudflared] %s", scanner.Text())
-		}
-	}()
-	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			log.Printf("[cloudflared] %s", scanner.Text())
-		}
-	}()
-	go func() {
-		if err := cmd.Wait(); err != nil {
-			log.Printf("cloudflared exited with error: %v", err)
-		} else {
-			log.Println("cloudflared exited successfully")
-		}
-		os.Exit(1)
-	}()
-	log.Println("cloudflared started")
+
+	m.cmd = cmd
+	m.done = make(chan struct{})
+	m.running = true
+	m.stopRequested = false
+	m.errorMessage = ""
+	m.message = "cloudflared is running"
+	m.appendLogLocked(fmt.Sprintf("started cloudflared (pid=%d)", cmd.Process.Pid))
+
+	go m.scanPipe(stdout, false)
+	go m.scanPipe(stderr, true)
+	go m.waitProcess(cmd, m.done)
+
 	return nil
 }
 
-func Kill() {
-	if cloudflaredCmd != nil && cloudflaredCmd.Process != nil {
-		err := cloudflaredCmd.Process.Kill()
-		if err != nil {
-			log.Printf("failed to kill cloudflared: %v", err)
-		} else {
-			log.Println("cloudflared killed")
-		}
-		cloudflaredCmd = nil
+func (m *manager) stop() error {
+	m.mu.RLock()
+	cmd := m.cmd
+	done := m.done
+	running := m.running
+	m.mu.RUnlock()
+
+	if !running || cmd == nil || cmd.Process == nil {
+		return nil
 	}
+
+	m.mu.Lock()
+	m.stopRequested = true
+	m.message = "stopping cloudflared..."
+	m.mu.Unlock()
+
+	var signalErr error
+	if runtime.GOOS == "windows" {
+		signalErr = cmd.Process.Kill()
+	} else {
+		signalErr = cmd.Process.Signal(syscall.SIGTERM)
+	}
+	if signalErr != nil {
+		return signalErr
+	}
+
+	if done != nil {
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			_ = cmd.Process.Kill()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *manager) waitProcess(cmd *exec.Cmd, done chan struct{}) {
+	err := cmd.Wait()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err != nil {
+		if m.stopRequested {
+			m.message = "cloudflared stopped"
+			m.errorMessage = ""
+			m.appendLogLocked("cloudflared stopped")
+		} else {
+			m.message = "cloudflared exited unexpectedly"
+			m.errorMessage = err.Error()
+			m.appendLogLocked("cloudflared exited unexpectedly: " + err.Error())
+		}
+	} else {
+		m.message = "cloudflared stopped"
+		if !m.stopRequested {
+			m.errorMessage = ""
+		}
+		m.appendLogLocked("cloudflared stopped")
+	}
+
+	m.cmd = nil
+	m.running = false
+	m.stopRequested = false
+	close(done)
+}
+
+func (m *manager) scanPipe(reader io.ReadCloser, isErr bool) {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		m.mu.Lock()
+		if isErr || looksLikeError(line) {
+			m.errorMessage = line
+		}
+		m.message = line
+		m.appendLogLocked(line)
+		m.mu.Unlock()
+	}
+}
+
+func (m *manager) status() RuntimeStatus {
+	binaryPath, installed := resolveBinaryPath()
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	status := RuntimeStatus{
+		Installed:       installed,
+		Running:         m.running,
+		Message:         m.message,
+		ErrorMessage:    m.errorMessage,
+		Logs:            append([]string{}, m.logs...),
+		BinaryPath:      binaryPath,
+		EnvTokenPresent: strings.TrimSpace(os.Getenv("KOMARI_CLOUDFLARED_TOKEN")) != "",
+	}
+	if m.cmd != nil && m.cmd.Process != nil {
+		status.PID = m.cmd.Process.Pid
+	}
+
+	token, err := loadStoredToken()
+	if err == nil && strings.TrimSpace(token) != "" {
+		status.TokenStored = true
+	}
+
+	return status
+}
+
+func (m *manager) setError(message string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.errorMessage = message
+	m.message = message
+	m.appendLogLocked(message)
+}
+
+func (m *manager) appendLogLocked(line string) {
+	m.logs = append(m.logs, line)
+	if len(m.logs) > m.maxLogLines {
+		m.logs = m.logs[len(m.logs)-m.maxLogLines:]
+	}
+}
+
+func loadStoredToken() (token string, err error) {
+	defer func() {
+		if recover() != nil {
+			token = ""
+			err = nil
+		}
+	}()
+
+	raw, err := config.GetAs[string](config.CloudflareTunnelTokenKey, "")
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(raw) == "" {
+		return "", nil
+	}
+
+	token, err = secureconfig.DecryptString(raw)
+	if err == nil {
+		return token, nil
+	}
+
+	return raw, nil
+}
+
+func resolveBinaryPath() (string, bool) {
+	candidates := []string{}
+	if envPath := strings.TrimSpace(os.Getenv("KOMARI_CLOUDFLARED_BIN")); envPath != "" {
+		candidates = append(candidates, envPath)
+	}
+
+	candidates = append(candidates, "cloudflared")
+	if runtime.GOOS == "windows" {
+		candidates = append(candidates,
+			filepath.Join("data", "cloudflared.exe"),
+			filepath.Join("data", "bin", "cloudflared.exe"),
+		)
+	} else {
+		candidates = append(candidates,
+			filepath.Join("data", "cloudflared"),
+			filepath.Join("data", "bin", "cloudflared"),
+			"/usr/local/bin/cloudflared",
+			"/usr/bin/cloudflared",
+		)
+	}
+
+	seen := map[string]struct{}{}
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path, true
+		}
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			if abs, absErr := filepath.Abs(candidate); absErr == nil {
+				return abs, true
+			}
+			return candidate, true
+		}
+	}
+
+	return "", false
+}
+
+func looksLikeError(line string) bool {
+	lower := strings.ToLower(line)
+	return strings.Contains(lower, "error") ||
+		strings.Contains(lower, "failed") ||
+		strings.Contains(lower, "invalid") ||
+		strings.Contains(lower, "unauthorized")
 }

--- a/utils/cloudflared/cloudflared_test.go
+++ b/utils/cloudflared/cloudflared_test.go
@@ -1,21 +1,28 @@
 package cloudflared_test
 
 import (
-	"os"
+	"encoding/json"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/komari-monitor/komari/utils/cloudflared"
 )
 
-func TestRunCloudflared(t *testing.T) {
-	os.Setenv("KOMARI_CLOUDFLARED_TOKEN", "test-token")
+func TestStatusDoesNotExposeToken(t *testing.T) {
+	const token = "test-cloudflare-token"
+	t.Setenv("KOMARI_CLOUDFLARED_TOKEN", token)
 
-	err := cloudflared.RunCloudflared()
-	if err != nil {
-		t.Fatalf("RunCloudflared failed: %v", err)
+	status := cloudflared.Status()
+	if !status.EnvTokenPresent {
+		t.Fatalf("expected environment token to be detected")
 	}
 
-	// 等待一段时间，确保子进程已启动
-	time.Sleep(2 * time.Second)
+	payload, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("failed to marshal status: %v", err)
+	}
+
+	if strings.Contains(string(payload), token) {
+		t.Fatalf("expected status payload not to contain the raw token")
+	}
 }

--- a/utils/secureconfig/secureconfig.go
+++ b/utils/secureconfig/secureconfig.go
@@ -1,0 +1,123 @@
+package secureconfig
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const keyFilePath = "./data/secret.key"
+
+func EncryptString(plaintext string) (string, error) {
+	key, err := loadOrCreateKey()
+	if err != nil {
+		return "", err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+
+	payload := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return base64.StdEncoding.EncodeToString(payload), nil
+}
+
+func DecryptString(ciphertext string) (string, error) {
+	if strings.TrimSpace(ciphertext) == "" {
+		return "", nil
+	}
+
+	key, err := loadOrCreateKey()
+	if err != nil {
+		return "", err
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(ciphertext)
+	if err != nil {
+		return "", err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	if len(raw) < gcm.NonceSize() {
+		return "", errors.New("ciphertext too short")
+	}
+
+	nonce := raw[:gcm.NonceSize()]
+	data := raw[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, data, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return string(plaintext), nil
+}
+
+func loadOrCreateKey() ([]byte, error) {
+	if env := strings.TrimSpace(os.Getenv("KOMARI_SECRET_KEY")); env != "" {
+		return normalizeKey(env)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(keyFilePath), 0700); err != nil {
+		return nil, err
+	}
+
+	if data, err := os.ReadFile(keyFilePath); err == nil {
+		return normalizeKey(strings.TrimSpace(string(data)))
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(key)
+	if err := os.WriteFile(keyFilePath, []byte(encoded), 0600); err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}
+
+func normalizeKey(input string) ([]byte, error) {
+	if decoded, err := base64.StdEncoding.DecodeString(input); err == nil {
+		if len(decoded) == 32 {
+			return decoded, nil
+		}
+	}
+
+	if len(input) >= 16 {
+		sum := sha256.Sum256([]byte(input))
+		return sum[:], nil
+	}
+
+	return nil, fmt.Errorf("invalid secret key length")
+}


### PR DESCRIPTION
## Summary

This PR improves Komari's existing `cloudflared` integration and turns it into an admin-managed Cloudflare Tunnel workflow closer to Uptime Kuma's Reverse Proxy experience.

It adds:

- persistent Cloudflare Tunnel token storage
- encrypted token persistence
- start / stop / remove token admin APIs
- cloudflared runtime status and recent log reporting
- automatic restore on restart when a token is stored or passed by environment variable
- Docker image bundling of the `cloudflared` binary

## Changes

### Backend

- add a dedicated cloudflared manager under `utils/cloudflared`
- add admin APIs under `/api/admin/settings/cloudflared`
  - `GET /cloudflared`
  - `POST /cloudflared/start`
  - `POST /cloudflared/stop`
  - `POST /cloudflared/remove-token`
- store the token in config as `cloudflare_tunnel_token`
- encrypt the stored token using a local secret key or `KOMARI_SECRET_KEY`
- persist the token as part of the start flow when a token is provided
- stop returning the raw token to the frontend
- require admin re-validation before stopping cloudflared

### Docker

- keep the existing Alpine-based runtime image
- bundle `cloudflared` in the Docker image so Docker deployments can start tunnels directly inside the container without changing the project's existing base image choice

## Security

- the token is passed to `cloudflared` through the process environment instead of CLI arguments
- the status API never returns the raw token
- when password login is enabled, stopping cloudflared requires the current password
- when password login is disabled, stopping cloudflared requires typing `STOP CLOUDFLARED`

## Verification

- `go test ./api/admin ./cmd ./public ./utils/cloudflared`
- `go build` with the frontend build output placed under `public/defaultTheme`

## Notes

The admin settings page for this backend support is implemented in a separate companion PR against `komari-web`.

## Companion frontend PR: 
https://github.com/komari-monitor/komari-web/pull/57

## Screenshot
<img width="1351" height="740" alt="Snipaste_2026-04-15_23-38-50" src="https://github.com/user-attachments/assets/43d595bc-de17-4b3a-af67-3d9284ba354c" />


## Note regarding Caddy/Custom Wallpapers:
In my personal fork, I use Caddy to serve dynamic wallpapers for Komari. I have excluded those instructions from this PR to keep the scope focused purely on the cloudflared integration. If you believe adding a section about "Advanced Setup with Caddy/Wallpapers" to the documentation would be beneficial, I am happy to add it in a follow-up commit.

<img width="1455" height="978" alt="image" src="https://github.com/user-attachments/assets/15524fca-98a5-439e-9422-f0714debf71c" />

