### PR TITLE
fix: Optimize database indexes and improve performance on I/O-constrained hosts

### DIFF
--- a/database/dbcore/dbcore.go
+++ b/database/dbcore/dbcore.go
@@ -424,7 +424,9 @@ func GetDBInstance() *gorm.DB {
 			if err := instance.Exec("PRAGMA journal_mode = WAL;").Error; err != nil {
 				log.Printf("Failed to enable WAL mode for SQLite: %v", err)
 			}
-			instance.Exec("VACUUM;")
+			instance.Exec("PRAGMA synchronous = NORMAL;")
+			instance.Exec("PRAGMA cache_size = -65536;")
+			instance.Exec("PRAGMA temp_store = MEMORY;")
 			instance.Exec("PRAGMA wal_checkpoint(TRUNCATE);")
 		// case "mysql":
 		// 	// MySQL 连接
@@ -488,6 +490,15 @@ func GetDBInstance() *gorm.DB {
 		)
 		if err != nil {
 			log.Printf("Failed to create Task and TaskResult table, it may already exist: %v", err)
+		}
+
+		// Manually create composite indexes
+		if flags.DatabaseType == "sqlite" || flags.DatabaseType == "" {
+			instance.Exec("CREATE INDEX IF NOT EXISTS idx_record_client_time ON records(client, time)")
+			instance.Exec("CREATE INDEX IF NOT EXISTS idx_record_lt_client_time ON records_long_term(client, time)")
+			instance.Exec("CREATE INDEX IF NOT EXISTS idx_gpu_record_client_time ON gpu_records(client, time)")
+			instance.Exec("CREATE INDEX IF NOT EXISTS idx_gpu_record_lt_client_time ON gpu_records_long_term(client, time)")
+			instance.Exec("CREATE INDEX IF NOT EXISTS idx_ping_record_client_time ON ping_records(client, time)")
 		}
 
 	})

--- a/database/records/records.go
+++ b/database/records/records.go
@@ -173,10 +173,7 @@ func CompactRecord() error {
 	}
 
 	if flags.DatabaseType == "sqlite" {
-		if err := db.Exec("VACUUM").Error; err != nil {
-			log.Printf("Error vacuuming database: %v", err)
-		}
-		db.Exec("PRAGMA wal_checkpoint(TRUNCATE);")
+		db.Exec("PRAGMA wal_checkpoint(PASSIVE);")
 	}
 	//log.Printf("Record compaction completed")
 	return nil


### PR DESCRIPTION
Created composite indexes based on the currently query patterns to mitigate the I/O blocking issue mentioned by https://github.com/komari-monitor/komari/issues/371
. Also removed the database rewrite on every startup, considering that the system continuously writes data, with clients reporting every few seconds.

Note: **On I/O-constrained hosts with a large database, the initial index creation may take a long time**. However, the performance gain is significant: page access on my host improved from 3–60s (or even timing out) to around under 1s.