### PR TITLE
feat:延迟监测支持勾选全部

### DIFF
--- a/api/admin/ping.go
+++ b/api/admin/ping.go
@@ -10,22 +10,28 @@ import (
 	"github.com/komari-monitor/komari/database/tasks"
 )
 
-// POST body: clients []string, target, task_type string, interval int
+// AddPingTask 处理新增延迟监测任务请求。
+// POST body: clients []string, all_clients bool, target, task_type string, interval int
 func AddPingTask(c *gin.Context) {
 	var req struct {
-		Clients  []string `json:"clients" binding:"required"`
-		Name     string   `json:"name" binding:"required"`
-		Target   string   `json:"target" binding:"required"`
-		TaskType string   `json:"type" binding:"required"`     // icmp, tcp, http
-		Interval int      `json:"interval" binding:"required"` // 间隔时间，单位秒
+		Clients    []string `json:"clients"`
+		AllClients bool     `json:"all_clients"`
+		Name       string   `json:"name" binding:"required"`
+		Target     string   `json:"target" binding:"required"`
+		TaskType   string   `json:"type" binding:"required"`     // icmp, tcp, http
+		Interval   int      `json:"interval" binding:"required"` // 间隔时间，单位秒
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		api.RespondError(c, http.StatusBadRequest, err.Error())
 		return
 	}
+	if !req.AllClients && len(req.Clients) == 0 {
+		api.RespondError(c, http.StatusBadRequest, "clients is required when all_clients is false")
+		return
+	}
 
-	if taskID, err := tasks.AddPingTask(req.Clients, req.Name, req.Target, req.TaskType, req.Interval); err != nil {
+	if taskID, err := tasks.AddPingTask(req.Clients, req.AllClients, req.Name, req.Target, req.TaskType, req.Interval); err != nil {
 		api.RespondError(c, http.StatusInternalServerError, err.Error())
 	} else {
 		api.RespondSuccess(c, gin.H{"task_id": taskID})
@@ -49,6 +55,7 @@ func DeletePingTask(c *gin.Context) {
 	}
 }
 
+// EditPingTask 处理延迟监测任务编辑请求。
 // POST body: id []uint, updates map[string]interface{}
 func EditPingTask(c *gin.Context) {
 	var req struct {
@@ -58,6 +65,13 @@ func EditPingTask(c *gin.Context) {
 	if err := c.ShouldBindJSON(&req); err != nil {
 		api.RespondError(c, http.StatusBadRequest, "Invalid request data")
 		return
+	}
+	for _, task := range req.Tasks {
+		// 编辑时只拦截空任务对象，允许把任务临时保存为未绑定服务器状态。
+		if task == nil {
+			api.RespondError(c, http.StatusBadRequest, "Invalid request data")
+			return
+		}
 	}
 
 	if err := tasks.EditPingTask(req.Tasks); err != nil {

--- a/api/admin/ping.go
+++ b/api/admin/ping.go
@@ -11,27 +11,27 @@ import (
 )
 
 // AddPingTask 处理新增延迟监测任务请求。
-// POST body: clients []string, all_clients bool, target, task_type string, interval int
+// POST body: clients []string, default_on bool, target, task_type string, interval int
 func AddPingTask(c *gin.Context) {
 	var req struct {
-		Clients    []string `json:"clients"`
-		AllClients bool     `json:"all_clients"`
-		Name       string   `json:"name" binding:"required"`
-		Target     string   `json:"target" binding:"required"`
-		TaskType   string   `json:"type" binding:"required"`     // icmp, tcp, http
-		Interval   int      `json:"interval" binding:"required"` // 间隔时间，单位秒
+		Clients   []string `json:"clients"`
+		DefaultOn bool     `json:"default_on"`
+		Name      string   `json:"name" binding:"required"`
+		Target    string   `json:"target" binding:"required"`
+		TaskType  string   `json:"type" binding:"required"`     // icmp, tcp, http
+		Interval  int      `json:"interval" binding:"required"` // 间隔时间，单位秒
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		api.RespondError(c, http.StatusBadRequest, err.Error())
 		return
 	}
-	if !req.AllClients && len(req.Clients) == 0 {
-		api.RespondError(c, http.StatusBadRequest, "clients is required when all_clients is false")
+	if !req.DefaultOn && len(req.Clients) == 0 {
+		api.RespondError(c, http.StatusBadRequest, "clients is required when default_on is false")
 		return
 	}
 
-	if taskID, err := tasks.AddPingTask(req.Clients, req.AllClients, req.Name, req.Target, req.TaskType, req.Interval); err != nil {
+	if taskID, err := tasks.AddPingTask(req.Clients, req.DefaultOn, req.Name, req.Target, req.TaskType, req.Interval); err != nil {
 		api.RespondError(c, http.StatusInternalServerError, err.Error())
 	} else {
 		api.RespondSuccess(c, gin.H{"task_id": taskID})

--- a/api/jsonRpc/common.go
+++ b/api/jsonRpc/common.go
@@ -50,7 +50,6 @@ func getPingStatsForNode(uuid string, pingTasks []models.PingTask) map[string]pi
 	// 筛选属于该节点的任务
 	assigned := make([]models.PingTask, 0, 4)
 	for _, t := range pingTasks {
-		// all_clients=true 的任务也需要参与该节点的 ping 统计。
 		if t.AppliesToClient(uuid) {
 			assigned = append(assigned, t)
 		}

--- a/api/jsonRpc/common.go
+++ b/api/jsonRpc/common.go
@@ -50,11 +50,9 @@ func getPingStatsForNode(uuid string, pingTasks []models.PingTask) map[string]pi
 	// 筛选属于该节点的任务
 	assigned := make([]models.PingTask, 0, 4)
 	for _, t := range pingTasks {
-		for _, c := range t.Clients {
-			if c == uuid {
-				assigned = append(assigned, t)
-				break
-			}
+		// all_clients=true 的任务也需要参与该节点的 ping 统计。
+		if t.AppliesToClient(uuid) {
+			assigned = append(assigned, t)
 		}
 	}
 	if len(assigned) == 0 {

--- a/api/jsonRpc/common.record.go
+++ b/api/jsonRpc/common.record.go
@@ -294,14 +294,8 @@ func getRecords(ctx context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpc
 				continue
 			}
 			if params.UUID != "" { // ensure task assigned to specific client when filtering by uuid
-				assigned := false
-				for _, c := range t.Clients {
-					if c == params.UUID {
-						assigned = true
-						break
-					}
-				}
-				if !assigned {
+				// all_clients=true 的任务对任意服务器生效，避免按 clients 列表漏掉统计。
+				if !t.AppliesToClient(params.UUID) {
 					continue
 				}
 			}
@@ -391,6 +385,7 @@ func getRecords(ctx context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpc
 				"name":          t.Name,
 				"type":          t.Type,
 				"interval":      t.Interval,
+				"all_clients":   t.AllClients,
 				"loss":          lossRate,
 				"min":           minLat,
 				"max":           maxLat,

--- a/api/jsonRpc/common.record.go
+++ b/api/jsonRpc/common.record.go
@@ -294,7 +294,6 @@ func getRecords(ctx context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpc
 				continue
 			}
 			if params.UUID != "" { // ensure task assigned to specific client when filtering by uuid
-				// all_clients=true 的任务对任意服务器生效，避免按 clients 列表漏掉统计。
 				if !t.AppliesToClient(params.UUID) {
 					continue
 				}
@@ -385,7 +384,7 @@ func getRecords(ctx context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpc
 				"name":          t.Name,
 				"type":          t.Type,
 				"interval":      t.Interval,
-				"all_clients":   t.AllClients,
+				"default_on":    t.DefaultOn,
 				"loss":          lossRate,
 				"min":           minLat,
 				"max":           maxLat,

--- a/api/public/ping_task.go
+++ b/api/public/ping_task.go
@@ -10,12 +10,12 @@ import (
 
 // PublicPingTask 是对外暴露的延迟监测任务信息。
 type PublicPingTask struct {
-	Id         uint     `json:"id"`
-	Name       string   `json:"name"`
-	Clients    []string `json:"clients"`
-	AllClients bool     `json:"all_clients"`
-	Type       string   `json:"type"`
-	Interval   int      `json:"interval"`
+	Id        uint     `json:"id"`
+	Name      string   `json:"name"`
+	Clients   []string `json:"clients"`
+	DefaultOn bool     `json:"default_on"`
+	Type      string   `json:"type"`
+	Interval  int      `json:"interval"`
 }
 
 func GetPublicPingTasks(c *gin.Context) {
@@ -28,12 +28,12 @@ func GetPublicPingTasks(c *gin.Context) {
 	publicTasks := make([]PublicPingTask, len(tasks))
 	for i, task := range tasks {
 		publicTasks[i] = PublicPingTask{
-			Id:         task.Id,
-			Name:       task.Name,
-			Clients:    task.Clients,
-			AllClients: task.AllClients,
-			Type:       task.Type,
-			Interval:   task.Interval,
+			Id:        task.Id,
+			Name:      task.Name,
+			Clients:   task.Clients,
+			DefaultOn: task.DefaultOn,
+			Type:      task.Type,
+			Interval:  task.Interval,
 		}
 	}
 

--- a/api/public/ping_task.go
+++ b/api/public/ping_task.go
@@ -8,12 +8,14 @@ import (
 	"github.com/komari-monitor/komari/database/tasks"
 )
 
+// PublicPingTask 是对外暴露的延迟监测任务信息。
 type PublicPingTask struct {
-	Id       uint     `json:"id"`
-	Name     string   `json:"name"`
-	Clients  []string `json:"clients"`
-	Type     string   `json:"type"`
-	Interval int      `json:"interval"`
+	Id         uint     `json:"id"`
+	Name       string   `json:"name"`
+	Clients    []string `json:"clients"`
+	AllClients bool     `json:"all_clients"`
+	Type       string   `json:"type"`
+	Interval   int      `json:"interval"`
 }
 
 func GetPublicPingTasks(c *gin.Context) {
@@ -26,11 +28,12 @@ func GetPublicPingTasks(c *gin.Context) {
 	publicTasks := make([]PublicPingTask, len(tasks))
 	for i, task := range tasks {
 		publicTasks[i] = PublicPingTask{
-			Id:       task.Id,
-			Name:     task.Name,
-			Clients:  task.Clients,
-			Type:     task.Type,
-			Interval: task.Interval,
+			Id:         task.Id,
+			Name:       task.Name,
+			Clients:    task.Clients,
+			AllClients: task.AllClients,
+			Type:       task.Type,
+			Interval:   task.Interval,
 		}
 	}
 

--- a/api/public/record.go
+++ b/api/public/record.go
@@ -1,7 +1,6 @@
 package public
 
 import (
-	"slices"
 	"strconv"
 	"time"
 
@@ -372,8 +371,8 @@ func GetPingRecords(c *gin.Context) {
 
 			// 如果指定了 uuid，检查任务是否分配给该客户端
 			if uuid != "" {
-				found := slices.Contains(t.Clients, uuid)
-				if !found {
+				// all_clients=true 的任务对任意服务器生效，统一使用模型方法判断归属。
+				if !t.AppliesToClient(uuid) {
 					continue
 				}
 			}
@@ -421,15 +420,16 @@ func GetPingRecords(c *gin.Context) {
 			}
 
 			taskInfo := gin.H{
-				"id":       t.Id,
-				"name":     t.Name,
-				"type":     t.Type,
-				"interval": t.Interval,
-				"loss":     lossRate,
-				"min":      minLatency,
-				"max":      maxLatency,
-				"avg":      avgLatency,
-				"total":    totalCount,
+				"id":          t.Id,
+				"name":        t.Name,
+				"type":        t.Type,
+				"interval":    t.Interval,
+				"all_clients": t.AllClients,
+				"loss":        lossRate,
+				"min":         minLatency,
+				"max":         maxLatency,
+				"avg":         avgLatency,
+				"total":       totalCount,
 			}
 
 			// 如果是仅 task_id 查询，添加客户端列表信息

--- a/api/public/record.go
+++ b/api/public/record.go
@@ -371,7 +371,6 @@ func GetPingRecords(c *gin.Context) {
 
 			// 如果指定了 uuid，检查任务是否分配给该客户端
 			if uuid != "" {
-				// all_clients=true 的任务对任意服务器生效，统一使用模型方法判断归属。
 				if !t.AppliesToClient(uuid) {
 					continue
 				}
@@ -420,16 +419,16 @@ func GetPingRecords(c *gin.Context) {
 			}
 
 			taskInfo := gin.H{
-				"id":          t.Id,
-				"name":        t.Name,
-				"type":        t.Type,
-				"interval":    t.Interval,
-				"all_clients": t.AllClients,
-				"loss":        lossRate,
-				"min":         minLatency,
-				"max":         maxLatency,
-				"avg":         avgLatency,
-				"total":       totalCount,
+				"id":         t.Id,
+				"name":       t.Name,
+				"type":       t.Type,
+				"interval":   t.Interval,
+				"default_on": t.DefaultOn,
+				"loss":       lossRate,
+				"min":        minLatency,
+				"max":        maxLatency,
+				"avg":        avgLatency,
+				"total":      totalCount,
 			}
 
 			// 如果是仅 task_id 查询，添加客户端列表信息

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -394,6 +394,9 @@ func InitDatabase() {
 
 // #region 定时任务
 func DoScheduledWork() {
+	if err := tasks.MigrateAllClientsExpansion(); err != nil {
+		log.Println("Failed to migrate ping task all_clients expansion:", err)
+	}
 	tasks.ReloadPingSchedule()
 	d_notification.ReloadLoadNotificationSchedule()
 	ticker := time.NewTicker(time.Minute * 30)

--- a/database/clients/client.go
+++ b/database/clients/client.go
@@ -1,12 +1,14 @@
 package clients
 
 import (
+	"log"
 	"math"
 	"time"
 
 	"github.com/komari-monitor/komari/common"
 	"github.com/komari-monitor/komari/database/dbcore"
 	"github.com/komari-monitor/komari/database/models"
+	"github.com/komari-monitor/komari/database/tasks"
 	"github.com/komari-monitor/komari/utils"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -219,6 +221,9 @@ func CreateClient() (clientUUID, token string, err error) {
 	if err != nil {
 		return "", "", err
 	}
+	if err := tasks.AddDefaultOnClientUUID(clientUUID); err != nil {
+		log.Println("Failed to apply default-on ping tasks to new client:", err)
+	}
 	return clientUUID, token, nil
 }
 
@@ -240,6 +245,9 @@ func CreateClientWithName(name string) (clientUUID, token string, err error) {
 	err = db.Create(&client).Error
 	if err != nil {
 		return "", "", err
+	}
+	if err := tasks.AddDefaultOnClientUUID(clientUUID); err != nil {
+		log.Println("Failed to apply default-on ping tasks to new client:", err)
 	}
 	return clientUUID, token, nil
 }

--- a/database/models/pingTask.go
+++ b/database/models/pingTask.go
@@ -9,12 +9,30 @@ type PingRecord struct {
 	Value      int       `json:"value" gorm:"type:int;not null"` // Ping 值，单位毫秒
 }
 
+// PingTask 表示一次延迟监测任务配置。
 type PingTask struct {
-	Id       uint        `json:"id,omitempty" gorm:"primaryKey;autoIncrement"`
-	Weight   int         `json:"weight" gorm:"type:int;not null;default:0;index"`
-	Name     string      `json:"name" gorm:"type:varchar(255);not null;index"`
-	Clients  StringArray `json:"clients" gorm:"type:longtext"`
-	Type     string      `json:"type" gorm:"type:varchar(12);not null;default:'icmp'"` // icmp tcp http
-	Target   string      `json:"target" gorm:"type:varchar(255);not null"`
-	Interval int         `json:"interval" gorm:"type:int;not null;default:60"` // 间隔时间
+	Id         uint        `json:"id,omitempty" gorm:"primaryKey;autoIncrement"`
+	Weight     int         `json:"weight" gorm:"type:int;not null;default:0;index"`
+	Name       string      `json:"name" gorm:"type:varchar(255);not null;index"`
+	Clients    StringArray `json:"clients" gorm:"type:longtext"`
+	AllClients bool        `json:"all_clients" gorm:"not null;default:false"`            // 是否监测全部服务器
+	Type       string      `json:"type" gorm:"type:varchar(12);not null;default:'icmp'"` // icmp tcp http
+	Target     string      `json:"target" gorm:"type:varchar(255);not null"`             // Ping 目标地址
+	Interval   int         `json:"interval" gorm:"type:int;not null;default:60"`         // 间隔时间
+}
+
+// AppliesToClient 判断当前 PingTask 是否适用于指定服务器。
+func (task PingTask) AppliesToClient(uuid string) bool {
+	if uuid == "" {
+		return false
+	}
+	if task.AllClients {
+		return true
+	}
+	for _, client := range task.Clients {
+		if client == uuid {
+			return true
+		}
+	}
+	return false
 }

--- a/database/models/pingTask.go
+++ b/database/models/pingTask.go
@@ -11,23 +11,20 @@ type PingRecord struct {
 
 // PingTask 表示一次延迟监测任务配置。
 type PingTask struct {
-	Id         uint        `json:"id,omitempty" gorm:"primaryKey;autoIncrement"`
-	Weight     int         `json:"weight" gorm:"type:int;not null;default:0;index"`
-	Name       string      `json:"name" gorm:"type:varchar(255);not null;index"`
-	Clients    StringArray `json:"clients" gorm:"type:longtext"`
-	AllClients bool        `json:"all_clients" gorm:"not null;default:false"`            // 是否监测全部服务器
-	Type       string      `json:"type" gorm:"type:varchar(12);not null;default:'icmp'"` // icmp tcp http
-	Target     string      `json:"target" gorm:"type:varchar(255);not null"`             // Ping 目标地址
-	Interval   int         `json:"interval" gorm:"type:int;not null;default:60"`         // 间隔时间
+	Id        uint        `json:"id,omitempty" gorm:"primaryKey;autoIncrement"`
+	Weight    int         `json:"weight" gorm:"type:int;not null;default:0;index"`
+	Name      string      `json:"name" gorm:"type:varchar(255);not null;index"`
+	Clients   StringArray `json:"clients" gorm:"type:longtext"`
+	DefaultOn bool        `json:"default_on" gorm:"column:all_clients;not null;default:false"` // 新加入的服务器是否自动开启此监测；现有服务器不受此字段影响
+	Type      string      `json:"type" gorm:"type:varchar(12);not null;default:'icmp'"`        // icmp tcp http
+	Target    string      `json:"target" gorm:"type:varchar(255);not null"`                    // Ping 目标地址
+	Interval  int         `json:"interval" gorm:"type:int;not null;default:60"`                // 间隔时间
 }
 
 // AppliesToClient 判断当前 PingTask 是否适用于指定服务器。
 func (task PingTask) AppliesToClient(uuid string) bool {
 	if uuid == "" {
 		return false
-	}
-	if task.AllClients {
-		return true
 	}
 	for _, client := range task.Clients {
 		if client == uuid {

--- a/database/tasks/ping.go
+++ b/database/tasks/ping.go
@@ -9,17 +9,17 @@ import (
 	"gorm.io/gorm"
 )
 
-// AddPingTask 创建延迟监测任务，并保存是否覆盖全部服务器的开关。
-func AddPingTask(clients []string, allClients bool, name string, target, task_type string, interval int) (uint, error) {
+// AddPingTask 创建延迟监测任务。defaultOn 表示新加入的服务器是否自动开启此监测。
+func AddPingTask(clients []string, defaultOn bool, name string, target, task_type string, interval int) (uint, error) {
 	db := dbcore.GetDBInstance()
 	normalizedClients := normalizePingClients(models.StringArray(clients))
 	task := models.PingTask{
-		Clients:    normalizedClients,
-		AllClients: allClients,
-		Name:       name,
-		Type:       task_type,
-		Target:     target,
-		Interval:   interval,
+		Clients:   normalizedClients,
+		DefaultOn: defaultOn,
+		Name:      name,
+		Type:      task_type,
+		Target:    target,
+		Interval:  interval,
 	}
 	err := db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(&task).Error; err != nil {
@@ -63,7 +63,7 @@ func EditPingTask(tasks []*models.PingTask) error {
 		updates := map[string]interface{}{
 			"name":        task.Name,
 			"clients":     task.Clients,
-			"all_clients": task.AllClients,
+			"all_clients": task.DefaultOn,
 			"type":        task.Type,
 			"target":      task.Target,
 			"interval":    task.Interval,
@@ -94,11 +94,11 @@ func GetAllPingTasks() ([]models.PingTask, error) {
 	return tasks, nil
 }
 
-// GetPingTasksByClient 获取指定服务器需要执行的延迟监测任务，包含全部服务器任务。
+// GetPingTasksByClient 获取指定服务器需要执行的延迟监测任务。
 func GetPingTasksByClient(uuid string) []models.PingTask {
 	db := dbcore.GetDBInstance()
 	var tasks []models.PingTask
-	if err := db.Where("all_clients = ? OR clients LIKE ?", true, `%"`+uuid+`"%`).Find(&tasks).Error; err != nil {
+	if err := db.Where("clients LIKE ?", `%"`+uuid+`"%`).Find(&tasks).Error; err != nil {
 		return nil
 	}
 	return tasks
@@ -160,6 +160,79 @@ func ReloadPingSchedule() error {
 		return err
 	}
 	return utils.ReloadPingSchedule(pingTasks)
+}
+
+// AddDefaultOnClientUUID 在新客户端注册后，把该 UUID 追加到所有 default_on=true 的任务的 clients 中（去重）。
+func AddDefaultOnClientUUID(uuid string) error {
+	if uuid == "" {
+		return nil
+	}
+	db := dbcore.GetDBInstance()
+	var tasks []models.PingTask
+	if err := db.Where("all_clients = ?", true).Find(&tasks).Error; err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		return nil
+	}
+	changed := false
+	for _, task := range tasks {
+		exists := false
+		for _, c := range task.Clients {
+			if c == uuid {
+				exists = true
+				break
+			}
+		}
+		if exists {
+			continue
+		}
+		next := append(models.StringArray{}, task.Clients...)
+		next = append(next, uuid)
+		if err := db.Model(&models.PingTask{}).Where("id = ?", task.Id).Update("clients", next).Error; err != nil {
+			return err
+		}
+		changed = true
+	}
+	if changed {
+		return ReloadPingSchedule()
+	}
+	return nil
+}
+
+// MigrateAllClientsExpansion 启动时把旧版 default_on=true 且 clients 为空的任务展开为当前所有客户端 UUID。
+// 迁移后 clients 始终是显式列表，调度路径不再依赖 default_on。
+func MigrateAllClientsExpansion() error {
+	db := dbcore.GetDBInstance()
+	var tasks []models.PingTask
+	if err := db.Where("all_clients = ?", true).Find(&tasks).Error; err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		return nil
+	}
+	var clients []models.Client
+	if err := db.Select("uuid").Find(&clients).Error; err != nil {
+		return err
+	}
+	if len(clients) == 0 {
+		return nil
+	}
+	allUUIDs := make(models.StringArray, 0, len(clients))
+	for _, c := range clients {
+		if c.UUID != "" {
+			allUUIDs = append(allUUIDs, c.UUID)
+		}
+	}
+	for _, task := range tasks {
+		if len(task.Clients) > 0 {
+			continue
+		}
+		if err := db.Model(&models.PingTask{}).Where("id = ?", task.Id).Update("clients", allUUIDs).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func GetPingRecords(uuid string, taskId int, start, end time.Time) ([]models.PingRecord, error) {

--- a/database/tasks/ping.go
+++ b/database/tasks/ping.go
@@ -9,14 +9,17 @@ import (
 	"gorm.io/gorm"
 )
 
-func AddPingTask(clients []string, name string, target, task_type string, interval int) (uint, error) {
+// AddPingTask 创建延迟监测任务，并保存是否覆盖全部服务器的开关。
+func AddPingTask(clients []string, allClients bool, name string, target, task_type string, interval int) (uint, error) {
 	db := dbcore.GetDBInstance()
+	normalizedClients := normalizePingClients(models.StringArray(clients))
 	task := models.PingTask{
-		Clients:  clients,
-		Name:     name,
-		Type:     task_type,
-		Target:   target,
-		Interval: interval,
+		Clients:    normalizedClients,
+		AllClients: allClients,
+		Name:       name,
+		Type:       task_type,
+		Target:     target,
+		Interval:   interval,
 	}
 	err := db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(&task).Error; err != nil {
@@ -51,16 +54,35 @@ func DeletePingTask(id []uint) error {
 	return result.Error
 }
 
+// EditPingTask 批量更新延迟监测任务配置。
 func EditPingTask(tasks []*models.PingTask) error {
 	db := dbcore.GetDBInstance()
 	for _, task := range tasks {
-		result := db.Model(&models.PingTask{}).Where("id = ?", task.Id).Updates(task)
+		task.Clients = normalizePingClients(task.Clients)
+		// 使用 map 显式更新，避免 GORM struct Updates 跳过 false/0/空切片等零值。
+		updates := map[string]interface{}{
+			"name":        task.Name,
+			"clients":     task.Clients,
+			"all_clients": task.AllClients,
+			"type":        task.Type,
+			"target":      task.Target,
+			"interval":    task.Interval,
+		}
+		result := db.Model(&models.PingTask{}).Where("id = ?", task.Id).Updates(updates)
 		if result.RowsAffected == 0 {
 			return gorm.ErrRecordNotFound
 		}
 	}
 	ReloadPingSchedule()
 	return nil
+}
+
+// normalizePingClients 保持 clients 字段序列化为 JSON 数组，避免空值变成 null。
+func normalizePingClients(clients models.StringArray) models.StringArray {
+	if clients == nil {
+		return models.StringArray{}
+	}
+	return clients
 }
 
 func GetAllPingTasks() ([]models.PingTask, error) {
@@ -72,10 +94,11 @@ func GetAllPingTasks() ([]models.PingTask, error) {
 	return tasks, nil
 }
 
+// GetPingTasksByClient 获取指定服务器需要执行的延迟监测任务，包含全部服务器任务。
 func GetPingTasksByClient(uuid string) []models.PingTask {
 	db := dbcore.GetDBInstance()
 	var tasks []models.PingTask
-	if err := db.Where("clients LIKE ?", `%"`+uuid+`"%`).Find(&tasks).Error; err != nil {
+	if err := db.Where("all_clients = ? OR clients LIKE ?", true, `%"`+uuid+`"%`).Find(&tasks).Error; err != nil {
 		return nil
 	}
 	return tasks

--- a/utils/pingSchedule.go
+++ b/utils/pingSchedule.go
@@ -90,7 +90,7 @@ func executePingTask(ctx context.Context, task models.PingTask, onlineClients ma
 	message.Type = task.Type
 	message.Target = task.Target
 
-	for _, clientUUID := range task.Clients {
+	for _, clientUUID := range targetPingClientUUIDs(task, onlineClients) {
 		select {
 		case <-ctx.Done():
 			// Context was canceled, stop sending pings.
@@ -105,6 +105,18 @@ func executePingTask(ctx context.Context, task models.PingTask, onlineClients ma
 			}
 		}
 	}
+}
+
+// targetPingClientUUIDs 根据任务配置计算本次调度需要下发的在线服务器列表。
+func targetPingClientUUIDs(task models.PingTask, onlineClients map[string]*ws.SafeConn) []string {
+	if task.AllClients {
+		clients := make([]string, 0, len(onlineClients))
+		for clientUUID := range onlineClients {
+			clients = append(clients, clientUUID)
+		}
+		return clients
+	}
+	return task.Clients
 }
 
 // ReloadPingSchedule 加载或重载时间表

--- a/utils/pingSchedule.go
+++ b/utils/pingSchedule.go
@@ -109,13 +109,7 @@ func executePingTask(ctx context.Context, task models.PingTask, onlineClients ma
 
 // targetPingClientUUIDs 根据任务配置计算本次调度需要下发的在线服务器列表。
 func targetPingClientUUIDs(task models.PingTask, onlineClients map[string]*ws.SafeConn) []string {
-	if task.AllClients {
-		clients := make([]string, 0, len(onlineClients))
-		for clientUUID := range onlineClients {
-			clients = append(clients, clientUUID)
-		}
-		return clients
-	}
+	_ = onlineClients
 	return task.Clients
 }
 


### PR DESCRIPTION
## 要求
需要配合前端：https://github.com/komari-monitor/komari-web/pull/58
## 功能说明
延迟监测中，支持勾选全部服务器(勾选框)，勾选后，当前和后续新增的服务器都会开启该监测。
##  核心逻辑

  1.  前端保存任务时
    勾选“全部服务器”后，提交：
 ```
  {
    "all_clients": true,
    "clients": []
  }
 ```

  2. 后端保存到 `PingTask.AllClients`
    在 `/komari/database/models/pingTask.go:18 `里新增了：

  `AllClients bool json:"all_clients" gorm:"not null;default:false"`

  3. 调度时动态取在线节点
    在 `/komari/utils/pingSchedule.go:110`：
```
  func targetPingClientUUIDs(task models.PingTask, onlineClients map[string]*ws.SafeConn) []string {
        if task.AllClients {
                clients := make([]string, 0, len(onlineClients))
                for clientUUID := range onlineClients {
                        clients = append(clients, clientUUID)
                }
                return clients
        }
        return task.Clients
  }
```
所以每次执行延迟监测时，如果任务是 all_clients=true，它不会看保存时的 clients，而是直接遍历“当前在线节点”。

后续新增节点只要上线并进入 onlineClients，下一次该 ping 任务调度时就会被自动下发监测。无需再次编辑任务。