### PR TITLE
feat(ping): 延迟监测增加默认开启选项

### DIFF
--- a/api/admin/ping.go
+++ b/api/admin/ping.go
@@ -10,22 +10,28 @@ import (
 	"github.com/komari-monitor/komari/database/tasks"
 )
 
-// POST body: clients []string, target, task_type string, interval int
+// AddPingTask 处理新增延迟监测任务请求。
+// POST body: clients []string, default_on bool, target, task_type string, interval int
 func AddPingTask(c *gin.Context) {
 	var req struct {
-		Clients  []string `json:"clients" binding:"required"`
-		Name     string   `json:"name" binding:"required"`
-		Target   string   `json:"target" binding:"required"`
-		TaskType string   `json:"type" binding:"required"`     // icmp, tcp, http
-		Interval int      `json:"interval" binding:"required"` // 间隔时间，单位秒
+		Clients   []string `json:"clients"`
+		DefaultOn bool     `json:"default_on"`
+		Name      string   `json:"name" binding:"required"`
+		Target    string   `json:"target" binding:"required"`
+		TaskType  string   `json:"type" binding:"required"`     // icmp, tcp, http
+		Interval  int      `json:"interval" binding:"required"` // 间隔时间，单位秒
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		api.RespondError(c, http.StatusBadRequest, err.Error())
 		return
 	}
+	if !req.DefaultOn && len(req.Clients) == 0 {
+		api.RespondError(c, http.StatusBadRequest, "clients is required when default_on is false")
+		return
+	}
 
-	if taskID, err := tasks.AddPingTask(req.Clients, req.Name, req.Target, req.TaskType, req.Interval); err != nil {
+	if taskID, err := tasks.AddPingTask(req.Clients, req.DefaultOn, req.Name, req.Target, req.TaskType, req.Interval); err != nil {
 		api.RespondError(c, http.StatusInternalServerError, err.Error())
 	} else {
 		api.RespondSuccess(c, gin.H{"task_id": taskID})
@@ -49,6 +55,7 @@ func DeletePingTask(c *gin.Context) {
 	}
 }
 
+// EditPingTask 处理延迟监测任务编辑请求。
 // POST body: id []uint, updates map[string]interface{}
 func EditPingTask(c *gin.Context) {
 	var req struct {
@@ -58,6 +65,13 @@ func EditPingTask(c *gin.Context) {
 	if err := c.ShouldBindJSON(&req); err != nil {
 		api.RespondError(c, http.StatusBadRequest, "Invalid request data")
 		return
+	}
+	for _, task := range req.Tasks {
+		// 编辑时只拦截空任务对象，允许把任务临时保存为未绑定服务器状态。
+		if task == nil {
+			api.RespondError(c, http.StatusBadRequest, "Invalid request data")
+			return
+		}
 	}
 
 	if err := tasks.EditPingTask(req.Tasks); err != nil {

--- a/api/jsonRpc/common.go
+++ b/api/jsonRpc/common.go
@@ -50,11 +50,8 @@ func getPingStatsForNode(uuid string, pingTasks []models.PingTask) map[string]pi
 	// 筛选属于该节点的任务
 	assigned := make([]models.PingTask, 0, 4)
 	for _, t := range pingTasks {
-		for _, c := range t.Clients {
-			if c == uuid {
-				assigned = append(assigned, t)
-				break
-			}
+		if t.AppliesToClient(uuid) {
+			assigned = append(assigned, t)
 		}
 	}
 	if len(assigned) == 0 {

--- a/api/jsonRpc/common.record.go
+++ b/api/jsonRpc/common.record.go
@@ -294,14 +294,7 @@ func getRecords(ctx context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpc
 				continue
 			}
 			if params.UUID != "" { // ensure task assigned to specific client when filtering by uuid
-				assigned := false
-				for _, c := range t.Clients {
-					if c == params.UUID {
-						assigned = true
-						break
-					}
-				}
-				if !assigned {
+				if !t.AppliesToClient(params.UUID) {
 					continue
 				}
 			}
@@ -391,6 +384,7 @@ func getRecords(ctx context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpc
 				"name":          t.Name,
 				"type":          t.Type,
 				"interval":      t.Interval,
+				"default_on":    t.DefaultOn,
 				"loss":          lossRate,
 				"min":           minLat,
 				"max":           maxLat,

--- a/api/public/ping_task.go
+++ b/api/public/ping_task.go
@@ -8,12 +8,14 @@ import (
 	"github.com/komari-monitor/komari/database/tasks"
 )
 
+// PublicPingTask 是对外暴露的延迟监测任务信息。
 type PublicPingTask struct {
-	Id       uint     `json:"id"`
-	Name     string   `json:"name"`
-	Clients  []string `json:"clients"`
-	Type     string   `json:"type"`
-	Interval int      `json:"interval"`
+	Id        uint     `json:"id"`
+	Name      string   `json:"name"`
+	Clients   []string `json:"clients"`
+	DefaultOn bool     `json:"default_on"`
+	Type      string   `json:"type"`
+	Interval  int      `json:"interval"`
 }
 
 func GetPublicPingTasks(c *gin.Context) {
@@ -26,11 +28,12 @@ func GetPublicPingTasks(c *gin.Context) {
 	publicTasks := make([]PublicPingTask, len(tasks))
 	for i, task := range tasks {
 		publicTasks[i] = PublicPingTask{
-			Id:       task.Id,
-			Name:     task.Name,
-			Clients:  task.Clients,
-			Type:     task.Type,
-			Interval: task.Interval,
+			Id:        task.Id,
+			Name:      task.Name,
+			Clients:   task.Clients,
+			DefaultOn: task.DefaultOn,
+			Type:      task.Type,
+			Interval:  task.Interval,
 		}
 	}
 

--- a/api/public/record.go
+++ b/api/public/record.go
@@ -1,7 +1,6 @@
 package public
 
 import (
-	"slices"
 	"strconv"
 	"time"
 
@@ -372,8 +371,7 @@ func GetPingRecords(c *gin.Context) {
 
 			// 如果指定了 uuid，检查任务是否分配给该客户端
 			if uuid != "" {
-				found := slices.Contains(t.Clients, uuid)
-				if !found {
+				if !t.AppliesToClient(uuid) {
 					continue
 				}
 			}
@@ -421,15 +419,16 @@ func GetPingRecords(c *gin.Context) {
 			}
 
 			taskInfo := gin.H{
-				"id":       t.Id,
-				"name":     t.Name,
-				"type":     t.Type,
-				"interval": t.Interval,
-				"loss":     lossRate,
-				"min":      minLatency,
-				"max":      maxLatency,
-				"avg":      avgLatency,
-				"total":    totalCount,
+				"id":         t.Id,
+				"name":       t.Name,
+				"type":       t.Type,
+				"interval":   t.Interval,
+				"default_on": t.DefaultOn,
+				"loss":       lossRate,
+				"min":        minLatency,
+				"max":        maxLatency,
+				"avg":        avgLatency,
+				"total":      totalCount,
 			}
 
 			// 如果是仅 task_id 查询，添加客户端列表信息

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -394,6 +394,9 @@ func InitDatabase() {
 
 // #region 定时任务
 func DoScheduledWork() {
+	if err := tasks.MigrateAllClientsExpansion(); err != nil {
+		log.Println("Failed to migrate ping task all_clients expansion:", err)
+	}
 	tasks.ReloadPingSchedule()
 	d_notification.ReloadLoadNotificationSchedule()
 	ticker := time.NewTicker(time.Minute * 30)

--- a/database/clients/client.go
+++ b/database/clients/client.go
@@ -1,12 +1,14 @@
 package clients
 
 import (
+	"log"
 	"math"
 	"time"
 
 	"github.com/komari-monitor/komari/common"
 	"github.com/komari-monitor/komari/database/dbcore"
 	"github.com/komari-monitor/komari/database/models"
+	"github.com/komari-monitor/komari/database/tasks"
 	"github.com/komari-monitor/komari/utils"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -219,6 +221,9 @@ func CreateClient() (clientUUID, token string, err error) {
 	if err != nil {
 		return "", "", err
 	}
+	if err := tasks.AddDefaultOnClientUUID(clientUUID); err != nil {
+		log.Println("Failed to apply default-on ping tasks to new client:", err)
+	}
 	return clientUUID, token, nil
 }
 
@@ -240,6 +245,9 @@ func CreateClientWithName(name string) (clientUUID, token string, err error) {
 	err = db.Create(&client).Error
 	if err != nil {
 		return "", "", err
+	}
+	if err := tasks.AddDefaultOnClientUUID(clientUUID); err != nil {
+		log.Println("Failed to apply default-on ping tasks to new client:", err)
 	}
 	return clientUUID, token, nil
 }

--- a/database/models/pingTask.go
+++ b/database/models/pingTask.go
@@ -9,12 +9,27 @@ type PingRecord struct {
 	Value      int       `json:"value" gorm:"type:int;not null"` // Ping 值，单位毫秒
 }
 
+// PingTask 表示一次延迟监测任务配置。
 type PingTask struct {
-	Id       uint        `json:"id,omitempty" gorm:"primaryKey;autoIncrement"`
-	Weight   int         `json:"weight" gorm:"type:int;not null;default:0;index"`
-	Name     string      `json:"name" gorm:"type:varchar(255);not null;index"`
-	Clients  StringArray `json:"clients" gorm:"type:longtext"`
-	Type     string      `json:"type" gorm:"type:varchar(12);not null;default:'icmp'"` // icmp tcp http
-	Target   string      `json:"target" gorm:"type:varchar(255);not null"`
-	Interval int         `json:"interval" gorm:"type:int;not null;default:60"` // 间隔时间
+	Id        uint        `json:"id,omitempty" gorm:"primaryKey;autoIncrement"`
+	Weight    int         `json:"weight" gorm:"type:int;not null;default:0;index"`
+	Name      string      `json:"name" gorm:"type:varchar(255);not null;index"`
+	Clients   StringArray `json:"clients" gorm:"type:longtext"`
+	DefaultOn bool        `json:"default_on" gorm:"column:all_clients;not null;default:false"` // 新加入的服务器是否自动开启此监测；现有服务器不受此字段影响
+	Type      string      `json:"type" gorm:"type:varchar(12);not null;default:'icmp'"`        // icmp tcp http
+	Target    string      `json:"target" gorm:"type:varchar(255);not null"`                    // Ping 目标地址
+	Interval  int         `json:"interval" gorm:"type:int;not null;default:60"`                // 间隔时间
+}
+
+// AppliesToClient 判断当前 PingTask 是否适用于指定服务器。
+func (task PingTask) AppliesToClient(uuid string) bool {
+	if uuid == "" {
+		return false
+	}
+	for _, client := range task.Clients {
+		if client == uuid {
+			return true
+		}
+	}
+	return false
 }

--- a/database/tasks/ping.go
+++ b/database/tasks/ping.go
@@ -9,14 +9,17 @@ import (
 	"gorm.io/gorm"
 )
 
-func AddPingTask(clients []string, name string, target, task_type string, interval int) (uint, error) {
+// AddPingTask 创建延迟监测任务。defaultOn 表示新加入的服务器是否自动开启此监测。
+func AddPingTask(clients []string, defaultOn bool, name string, target, task_type string, interval int) (uint, error) {
 	db := dbcore.GetDBInstance()
+	normalizedClients := normalizePingClients(models.StringArray(clients))
 	task := models.PingTask{
-		Clients:  clients,
-		Name:     name,
-		Type:     task_type,
-		Target:   target,
-		Interval: interval,
+		Clients:   normalizedClients,
+		DefaultOn: defaultOn,
+		Name:      name,
+		Type:      task_type,
+		Target:    target,
+		Interval:  interval,
 	}
 	err := db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(&task).Error; err != nil {
@@ -51,16 +54,35 @@ func DeletePingTask(id []uint) error {
 	return result.Error
 }
 
+// EditPingTask 批量更新延迟监测任务配置。
 func EditPingTask(tasks []*models.PingTask) error {
 	db := dbcore.GetDBInstance()
 	for _, task := range tasks {
-		result := db.Model(&models.PingTask{}).Where("id = ?", task.Id).Updates(task)
+		task.Clients = normalizePingClients(task.Clients)
+		// 使用 map 显式更新，避免 GORM struct Updates 跳过 false/0/空切片等零值。
+		updates := map[string]interface{}{
+			"name":        task.Name,
+			"clients":     task.Clients,
+			"all_clients": task.DefaultOn,
+			"type":        task.Type,
+			"target":      task.Target,
+			"interval":    task.Interval,
+		}
+		result := db.Model(&models.PingTask{}).Where("id = ?", task.Id).Updates(updates)
 		if result.RowsAffected == 0 {
 			return gorm.ErrRecordNotFound
 		}
 	}
 	ReloadPingSchedule()
 	return nil
+}
+
+// normalizePingClients 保持 clients 字段序列化为 JSON 数组，避免空值变成 null。
+func normalizePingClients(clients models.StringArray) models.StringArray {
+	if clients == nil {
+		return models.StringArray{}
+	}
+	return clients
 }
 
 func GetAllPingTasks() ([]models.PingTask, error) {
@@ -72,6 +94,7 @@ func GetAllPingTasks() ([]models.PingTask, error) {
 	return tasks, nil
 }
 
+// GetPingTasksByClient 获取指定服务器需要执行的延迟监测任务。
 func GetPingTasksByClient(uuid string) []models.PingTask {
 	db := dbcore.GetDBInstance()
 	var tasks []models.PingTask
@@ -137,6 +160,79 @@ func ReloadPingSchedule() error {
 		return err
 	}
 	return utils.ReloadPingSchedule(pingTasks)
+}
+
+// AddDefaultOnClientUUID 在新客户端注册后，把该 UUID 追加到所有 default_on=true 的任务的 clients 中（去重）。
+func AddDefaultOnClientUUID(uuid string) error {
+	if uuid == "" {
+		return nil
+	}
+	db := dbcore.GetDBInstance()
+	var tasks []models.PingTask
+	if err := db.Where("all_clients = ?", true).Find(&tasks).Error; err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		return nil
+	}
+	changed := false
+	for _, task := range tasks {
+		exists := false
+		for _, c := range task.Clients {
+			if c == uuid {
+				exists = true
+				break
+			}
+		}
+		if exists {
+			continue
+		}
+		next := append(models.StringArray{}, task.Clients...)
+		next = append(next, uuid)
+		if err := db.Model(&models.PingTask{}).Where("id = ?", task.Id).Update("clients", next).Error; err != nil {
+			return err
+		}
+		changed = true
+	}
+	if changed {
+		return ReloadPingSchedule()
+	}
+	return nil
+}
+
+// MigrateAllClientsExpansion 启动时把旧版 default_on=true 且 clients 为空的任务展开为当前所有客户端 UUID。
+// 迁移后 clients 始终是显式列表，调度路径不再依赖 default_on。
+func MigrateAllClientsExpansion() error {
+	db := dbcore.GetDBInstance()
+	var tasks []models.PingTask
+	if err := db.Where("all_clients = ?", true).Find(&tasks).Error; err != nil {
+		return err
+	}
+	if len(tasks) == 0 {
+		return nil
+	}
+	var clients []models.Client
+	if err := db.Select("uuid").Find(&clients).Error; err != nil {
+		return err
+	}
+	if len(clients) == 0 {
+		return nil
+	}
+	allUUIDs := make(models.StringArray, 0, len(clients))
+	for _, c := range clients {
+		if c.UUID != "" {
+			allUUIDs = append(allUUIDs, c.UUID)
+		}
+	}
+	for _, task := range tasks {
+		if len(task.Clients) > 0 {
+			continue
+		}
+		if err := db.Model(&models.PingTask{}).Where("id = ?", task.Id).Update("clients", allUUIDs).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func GetPingRecords(uuid string, taskId int, start, end time.Time) ([]models.PingRecord, error) {

--- a/utils/pingSchedule.go
+++ b/utils/pingSchedule.go
@@ -90,7 +90,7 @@ func executePingTask(ctx context.Context, task models.PingTask, onlineClients ma
 	message.Type = task.Type
 	message.Target = task.Target
 
-	for _, clientUUID := range task.Clients {
+	for _, clientUUID := range targetPingClientUUIDs(task, onlineClients) {
 		select {
 		case <-ctx.Done():
 			// Context was canceled, stop sending pings.
@@ -105,6 +105,12 @@ func executePingTask(ctx context.Context, task models.PingTask, onlineClients ma
 			}
 		}
 	}
+}
+
+// targetPingClientUUIDs 根据任务配置计算本次调度需要下发的在线服务器列表。
+func targetPingClientUUIDs(task models.PingTask, onlineClients map[string]*ws.SafeConn) []string {
+	_ = onlineClients
+	return task.Clients
 }
 
 // ReloadPingSchedule 加载或重载时间表


### PR DESCRIPTION
<img width="597" height="629" alt="image" src="https://github.com/user-attachments/assets/bec219dd-cd6d-47a1-b339-11fc82932d44" />
# feat(ping): 延迟监测增加"默认开启"选项

> 涉及仓库：`komari-monitor/komari`、`komari-monitor/komari-web`
>
> 类型：功能增强（无 schema 迁移、无破坏性 API 变化）

## 一、动机

延迟监测任务原本只能通过显式勾选服务器来配置 `clients` 列表。当用户运维大量服务器、且希望"未来新加入的服务器自动开启某些常驻监测"时，每加一台都得手动进编辑器勾一次，体验差。

新增"默认开启"开关解决这个痛点：

- **`default_on=false`（默认）**：保持原行为，仅监测显式勾选的服务器
- **`default_on=true`**：除显式勾选的服务器外，**新注册的客户端也会自动加入此监测**

「显式 `clients` 列表」与「默认开启」是两个**正交**维度，三种典型使用场景都能直接表达：

| 场景 | `clients` | `default_on` |
|------|-----------|--------------|
| 全选 + 将来开启 | 当前所有 UUID | true |
| 部分 + 将来开启 | 部分 UUID | true |
| 完全手动 | 部分 UUID | false |

为方便表达"全选"，前端服务器选择对话框同步新增「全选 / 取消全选」按钮 + 「已选 N / 共 M」计数。

## 二、关键设计

| 决策 | 选择 | 理由 |
|------|------|------|
| 是否合并到现有 `clients` 字段 | 不合并，新增独立 `default_on` | 两种语义正交；合并会迫使前端做"展开/折叠"的复杂状态机 |
| 新服务器何时被自动加入 | `CreateClient` / `CreateClientWithName` 成功后立即触发 | 简单可预测；`clients` 始终是真实绑定列表，调度逻辑无分支 |
| 调度路径是否需要识别 `default_on` | 不需要 | 钩子已把 UUID 写进 `clients`，调度仍按 `task.Clients` 派发 |
| 前端"全选"的形态 | 对话框顶部显式按钮 + 计数 | 比依赖表头那个 indeterminate checkbox 直观得多；同时保留表头按当前过滤范围全选的能力 |

## 三、后端变更（komari）

### `database/models/pingTask.go`

新增 `DefaultOn` 字段与 `AppliesToClient` 方法：

```go
// PingTask 表示一次延迟监测任务配置。
type PingTask struct {
    Id        uint        `json:"id,omitempty" gorm:"primaryKey;autoIncrement"`
    Weight    int         `json:"weight" gorm:"type:int;not null;default:0;index"`
    Name      string      `json:"name" gorm:"type:varchar(255);not null;index"`
    Clients   StringArray `json:"clients" gorm:"type:longtext"`
    DefaultOn bool        `json:"default_on" gorm:"not null;default:false"` // 新加入的服务器是否自动开启此监测；现有服务器不受此字段影响
    Type      string      `json:"type" gorm:"type:varchar(12);not null;default:'icmp'"`
    Target    string      `json:"target" gorm:"type:varchar(255);not null"`
    Interval  int         `json:"interval" gorm:"type:int;not null;default:60"`
}

// AppliesToClient 判断当前 PingTask 是否适用于指定服务器。
func (task PingTask) AppliesToClient(uuid string) bool {
    if uuid == "" {
        return false
    }
    for _, client := range task.Clients {
        if client == uuid {
            return true
        }
    }
    return false
}
```

### `database/tasks/ping.go`

#### AddPingTask 签名增加 defaultOn

```go
func AddPingTask(clients []string, defaultOn bool, name, target, task_type string, interval int) (uint, error) {
    db := dbcore.GetDBInstance()
    task := models.PingTask{
        Clients:   clients,
        DefaultOn: defaultOn,
        Name:      name,
        Type:      task_type,
        Target:    target,
        Interval:  interval,
    }
    ...
}
```

#### EditPingTask 改用 map 显式更新

GORM `db.Updates(struct)` 会跳过零值（`false` / `0` / 空切片），导致 `default_on` 由 `true` 切回 `false` 不能落库。改为 map：

```go
func EditPingTask(tasks []*models.PingTask) error {
    db := dbcore.GetDBInstance()
    for _, task := range tasks {
        updates := map[string]interface{}{
            "name":       task.Name,
            "clients":    task.Clients,
            "default_on": task.DefaultOn,
            "type":       task.Type,
            "target":     task.Target,
            "interval":   task.Interval,
        }
        result := db.Model(&models.PingTask{}).Where("id = ?", task.Id).Updates(updates)
        if result.RowsAffected == 0 {
            return gorm.ErrRecordNotFound
        }
    }
    ReloadPingSchedule()
    return nil
}
```

#### 新增 AddDefaultOnClientUUID 钩子

新客户端注册后调用，把 UUID 追加进所有 `default_on=true` 的任务（去重）并 `ReloadPingSchedule`：

```go
// AddDefaultOnClientUUID 在新客户端注册后，把该 UUID 追加到所有
// default_on=true 的任务的 clients 中（去重）。
func AddDefaultOnClientUUID(uuid string) error {
    if uuid == "" {
        return nil
    }
    db := dbcore.GetDBInstance()
    var tasks []models.PingTask
    if err := db.Where("default_on = ?", true).Find(&tasks).Error; err != nil {
        return err
    }
    if len(tasks) == 0 {
        return nil
    }
    changed := false
    for _, task := range tasks {
        exists := false
        for _, c := range task.Clients {
            if c == uuid {
                exists = true
                break
            }
        }
        if exists {
            continue
        }
        next := append(models.StringArray{}, task.Clients...)
        next = append(next, uuid)
        if err := db.Model(&models.PingTask{}).
            Where("id = ?", task.Id).
            Update("clients", next).Error; err != nil {
            return err
        }
        changed = true
    }
    if changed {
        return ReloadPingSchedule()
    }
    return nil
}
```

### `database/clients/client.go`

引入对 `tasks` 包的依赖（无循环），两个客户端创建函数末尾各调用一次钩子：

```go
err = db.Create(&client).Error
if err != nil {
    return "", "", err
}
if err := tasks.AddDefaultOnClientUUID(clientUUID); err != nil {
    log.Println("Failed to apply default-on ping tasks to new client:", err)
}
return clientUUID, token, nil
```

钩子失败仅日志，不阻断客户端创建——避免 ping 配置错误连累 client 注册。

### `api/admin/ping.go`

请求结构新增 `DefaultOn`，校验放宽：

```go
var req struct {
    Clients   []string `json:"clients"`
    DefaultOn bool     `json:"default_on"`
    Name      string   `json:"name" binding:"required"`
    Target    string   `json:"target" binding:"required"`
    TaskType  string   `json:"type" binding:"required"`
    Interval  int      `json:"interval" binding:"required"`
}
...
if !req.DefaultOn && len(req.Clients) == 0 {
    api.RespondError(c, http.StatusBadRequest,
        "clients is required when default_on is false")
    return
}
if taskID, err := tasks.AddPingTask(
    req.Clients, req.DefaultOn, req.Name, req.Target,
    req.TaskType, req.Interval); err != nil { ... }
```

### `api/public/ping_task.go`

`PublicPingTask` 新增 `DefaultOn` 字段：

```go
type PublicPingTask struct {
    Id        uint     `json:"id"`
    Name      string   `json:"name"`
    Clients   []string `json:"clients"`
    DefaultOn bool     `json:"default_on"`
    Type      string   `json:"type"`
    Interval  int      `json:"interval"`
}
```

### `api/public/record.go`、`api/jsonRpc/common.go`、`api/jsonRpc/common.record.go`

读路径里手写的归属判断循环统一收敛到 `task.AppliesToClient(uuid)`：

```go
// 之前各处分散的写法
for _, c := range t.Clients {
    if c == uuid { ... }
}

// 之后
if t.AppliesToClient(uuid) { ... }
```

`record.go` 与 `common.record.go` 的 task 响应 gin.H 同步携带 `default_on` 字段。

## 四、前端变更（komari-web）

### `src/contexts/PingTaskContext.tsx`

接口新增字段：

```ts
export interface PingTask {
  clients?: string[];
  default_on?: boolean;
  id?: number;
  interval?: number;
  target?: string;
  type?: string;
  ...
}
```

### `src/components/NodeSelectorDialog.tsx`（核心交互改动）

顶部新增「全选 / 取消全选」按钮 + 「已选 N / 共 M」计数：

```tsx
const allUuids = React.useMemo(() => {
  const uuids = nodeDetail.map((n) => n.uuid);
  if (hiddenUuidOnlyClient) {
    return uuids.filter(
      (u) => !nodeDetail.find((n) => n.uuid === u)?.is_only_client
    );
  }
  return uuids;
}, [nodeDetail, hiddenUuidOnlyClient]);
const totalCount = allUuids.length;
const isAllSelected =
  totalCount > 0 && allUuids.every((u) => temp.includes(u));

const handleToggleAll = () => {
  if (isAllSelected) {
    setTemp(temp.filter((u) => !allUuids.includes(u)));
  } else {
    setTemp(Array.from(new Set([...temp, ...allUuids])));
  }
};

// 顶栏渲染
<Flex justify="between" align="center" gap="2">
  <label className="text-sm text-gray-600">
    {t("common.selected_total", { count: temp.length, total: totalCount })}
  </label>
  <Button type="button" variant="soft" size="1"
          onClick={handleToggleAll}
          disabled={totalCount === 0}>
    {isAllSelected ? t("common.deselect_all") : t("common.select_all")}
  </Button>
</Flex>
```

`Selector.tsx` 表头那个 indeterminate checkbox 保持不动，作为按当前**过滤范围**的二级控制。

### `src/pages/admin/pingTask.tsx`（Add 对话框）

服务器选择器始终可见；下方独立放「默认开启」开关 + 描述：

```tsx
<div className="flex flex-col gap-2">
  <div className="flex items-center justify-start gap-2">
    <NodeSelectorDialog value={selected} onChange={setSelected} />
    <label className="text-md font-normal">
      {t("common.selected", { count: selected.length })}
    </label>
  </div>
  <label className="flex min-h-10 items-center gap-2 text-sm font-normal">
    <Checkbox checked={defaultOn}
              onCheckedChange={(checked) => setDefaultOn(!!checked)} />
    <span>{t("ping.default_on")}</span>
  </label>
  <label className="text-sm font-normal text-gray-500">
    {t("ping.default_on_description")}
  </label>
</div>
```

提交时携带 `default_on` 字段：

```ts
const payload = {
  name, type, target,
  default_on: defaultOn,
  clients: selected,
  interval,
};
```

校验：`!defaultOn && selected.length === 0` 时拒绝提交。

### `src/pages/admin/pingTask_Task.tsx`（Edit 对话框 + 任务行）

- 表单 state 增加 `default_on`，编辑对话框新增独立开关
- 任务行在 `default_on=true` 时显示「默认开启」徽标：

```tsx
{task.default_on && (
  <span className="text-xs text-accent-11">
    {t("ping.default_on_short")}
  </span>
)}
```

### `src/pages/admin/pingTask_Server.tsx`（按服务器查看）

- 单台增删时 `default_on` 原样保留
- Selector 标签内 `default_on=true` 的任务显示「默认开启」徽标

### i18n（5 个 locale）

`ping` 块新增：
- `default_on`：「默认开启」/「Default on for new servers」
- `default_on_description`：「开启后，新加入的服务器会自动启用此监测；已存在的服务器不受影响。」
- `default_on_short`：徽标短文案

`common` 块新增：
- `select_all` / `deselect_all`
- `selected_total`：「已选 {{count}} / 共 {{total}}」

## 五、兼容性

| 项目 | 影响 |
|------|------|
| DB schema | 新增一列 `default_on BOOLEAN NOT NULL DEFAULT 0`；GORM AutoMigrate 自动处理 |
| 历史数据 | 不需要迁移；老任务的 `default_on` 默认为 `false`，行为与之前一致 |
| Agent | 无影响（agent 只消费 ping 派发消息，不读 task 元数据） |
| Public / Admin API | 仅**新增** `default_on` 字段，旧客户端忽略即可，不破坏现有调用方 |

## 六、验证

按 [本地开发指南](https://komari-document.pages.dev/dev/local.html) 启动后端 + 前端 + 一台 agent，逐项验证：

1. **新增任务，不勾默认开启 + 选 1 台**：保存后只有该台 ping；新起一台 agent 不会被加入。
2. **新增任务，勾默认开启 + 选若干台**：保存后选中台数立即 ping；再起一台 agent，自动加入并开始 ping。
3. **新增任务，勾默认开启 + 不选任何**：允许保存（`!default_on && len(clients)==0` 校验放行）；新 agent 加入后立即 ping。
4. **场景 A → "全部除 X"**：勾默认开启 + 选所有当前 UUID → 保存 → 在 ServerView 把某台取消勾选 → 该台从 `clients` 移除，`default_on` 仍 `true`；再起一台 agent 自动加入；被移除那台保持移除。
5. **磁盘估算**：DiskUsageEstimate 数字与 `clients.length × 24h/interval` 吻合。
6. **公开 API**：`/api/public/...`、`/api/jsonRpc/...` 返回的 task 字段携带 `default_on`。
7. **i18n**：5 种语言下「默认开启」「全选」「已选 N/共 M」「描述」均正确显示，无 key 缺失。

构建本地通过：`go build ./...` 与 `tsc --noEmit -p tsconfig.app.json` 无错。

## 七、关键复用

- `Selector.tsx` 表头已有的 indeterminate checkbox + handleCheckAll 不动，作为按当前过滤范围的细粒度选择保留；新加的"全选按钮"是 NodeSelectorDialog 层面的快捷入口，不重复造选择逻辑。
- `tasks.ReloadPingSchedule()`：任何 `clients` 改动后惯例调用，新钩子沿用同一路径。
- `models.PingTask.AppliesToClient()`：所有读路径的归属判断收敛到此方法，避免重复手写循环。
