### PR TITLE
Feat/add xtermjs setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ go.work.sum
 
 # build
 komari
+.codex

--- a/api/admin/settings_xtermjs.go
+++ b/api/admin/settings_xtermjs.go
@@ -3,6 +3,11 @@ package admin
 import (
 	"errors"
 	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/komari-monitor/komari/api"
+	"github.com/komari-monitor/komari/config"
+	"github.com/komari-monitor/komari/database/auditlog"
 )
 
 const (
@@ -223,4 +228,44 @@ func themeIsEmpty(theme *ThemeConfig) bool {
 		theme.BrightCyan == "" &&
 		theme.BrightWhite == "" &&
 		len(theme.ExtendedAnsi) == 0
+}
+
+func GetXtermJSSettings(c *gin.Context) {
+	defaultSettings := defaultXtermJSSettings()
+	settings, err := config.GetAs[XtermJSSettings](config.XtermjsSettingsKey, defaultSettings)
+	if err != nil {
+		_ = config.Set(config.XtermjsSettingsKey, defaultSettings)
+		settings = defaultSettings
+	}
+
+	normalized, err := normalizeXtermJSSettings(settings)
+	if err != nil {
+		api.RespondError(c, 500, "Failed to get xtermjs settings: "+err.Error())
+		return
+	}
+
+	api.RespondSuccess(c, normalized)
+}
+
+func SetXtermJSSettings(c *gin.Context) {
+	var settings XtermJSSettings
+	if err := c.ShouldBindJSON(&settings); err != nil {
+		api.RespondError(c, 400, "Invalid or missing request body: "+err.Error())
+		return
+	}
+
+	normalized, err := normalizeXtermJSSettings(settings)
+	if err != nil {
+		api.RespondError(c, 400, "Invalid xtermjs settings: "+err.Error())
+		return
+	}
+
+	if err := config.Set(config.XtermjsSettingsKey, normalized); err != nil {
+		api.RespondError(c, 500, "Failed to save settings: "+err.Error())
+		return
+	}
+
+	uuid, _ := c.Get("uuid")
+	auditlog.Log(c.ClientIP(), uuid.(string), "update xtermjs settings", "info")
+	api.RespondSuccessMessage(c, "settings saved", nil)
 }

--- a/api/admin/settings_xtermjs.go
+++ b/api/admin/settings_xtermjs.go
@@ -92,8 +92,7 @@ func normalizeXtermJSSettings(input XtermJSSettings) (XtermJSSettings, error) {
 
 		if fontFamily := strings.TrimSpace(input.TerminalOptions.FontFamily); fontFamily != "" {
 			options.FontFamily = fontFamily
-		}
-		if options.FontFamily == "" {
+		} else {
 			options.FontFamily = defaultXtermJSFontFamily
 		}
 

--- a/api/admin/settings_xtermjs.go
+++ b/api/admin/settings_xtermjs.go
@@ -1,0 +1,226 @@
+package admin
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	defaultXtermJSFontFamily = "'Cascadia Mono', 'Noto Sans SC', monospace"
+	defaultXtermJSFontSize   = 16
+	defaultXtermJSScrollback = 5000
+	defaultXtermJSPadding    = 16
+)
+
+// XtermJSSettings stores the admin-configurable xtermjs settings payload.
+type XtermJSSettings struct {
+	TerminalOptions       *TerminalOptions `json:"terminalOptions"`
+	TerminalPadding       *int             `json:"terminalPadding"`
+	TransparentBackground bool             `json:"transparentBackground"`
+	CustomCss             string           `json:"customCss"`
+}
+
+// TerminalOptions stores the xterm.js terminal options.
+type TerminalOptions struct {
+	CursorBlink     *bool        `json:"cursorBlink"`
+	ConvertEol      *bool        `json:"convertEol"`
+	FontFamily      string       `json:"fontFamily"`
+	FontSize        int          `json:"fontSize"`
+	MacOptionIsMeta *bool        `json:"macOptionIsMeta"`
+	Scrollback      *int         `json:"scrollback"`
+	Theme           *ThemeConfig `json:"theme"`
+}
+
+// ThemeConfig contains only the xterm.js theme whitelist from the API contract.
+type ThemeConfig struct {
+	Foreground                  string   `json:"foreground,omitempty"`
+	Background                  string   `json:"background,omitempty"`
+	Cursor                      string   `json:"cursor,omitempty"`
+	CursorAccent                string   `json:"cursorAccent,omitempty"`
+	SelectionForeground         string   `json:"selectionForeground,omitempty"`
+	SelectionBackground         string   `json:"selectionBackground,omitempty"`
+	SelectionInactiveBackground string   `json:"selectionInactiveBackground,omitempty"`
+	Black                       string   `json:"black,omitempty"`
+	Red                         string   `json:"red,omitempty"`
+	Green                       string   `json:"green,omitempty"`
+	Yellow                      string   `json:"yellow,omitempty"`
+	Blue                        string   `json:"blue,omitempty"`
+	Magenta                     string   `json:"magenta,omitempty"`
+	Cyan                        string   `json:"cyan,omitempty"`
+	White                       string   `json:"white,omitempty"`
+	BrightBlack                 string   `json:"brightBlack,omitempty"`
+	BrightRed                   string   `json:"brightRed,omitempty"`
+	BrightGreen                 string   `json:"brightGreen,omitempty"`
+	BrightYellow                string   `json:"brightYellow,omitempty"`
+	BrightBlue                  string   `json:"brightBlue,omitempty"`
+	BrightMagenta               string   `json:"brightMagenta,omitempty"`
+	BrightCyan                  string   `json:"brightCyan,omitempty"`
+	BrightWhite                 string   `json:"brightWhite,omitempty"`
+	ExtendedAnsi                []string `json:"extendedAnsi,omitempty"`
+}
+
+func defaultXtermJSSettings() XtermJSSettings {
+	return XtermJSSettings{
+		TerminalOptions: &TerminalOptions{
+			CursorBlink:     boolPtr(true),
+			ConvertEol:      boolPtr(true),
+			FontFamily:      defaultXtermJSFontFamily,
+			FontSize:        defaultXtermJSFontSize,
+			MacOptionIsMeta: boolPtr(true),
+			Scrollback:      intPtr(defaultXtermJSScrollback),
+			Theme:           nil,
+		},
+		TerminalPadding:       intPtr(defaultXtermJSPadding),
+		TransparentBackground: false,
+		CustomCss:             "",
+	}
+}
+
+func normalizeXtermJSSettings(input XtermJSSettings) (XtermJSSettings, error) {
+	normalized := defaultXtermJSSettings()
+
+	if input.TerminalOptions != nil {
+		options := *input.TerminalOptions
+		options.CursorBlink = boolOrDefault(input.TerminalOptions.CursorBlink, true)
+		options.ConvertEol = boolOrDefault(input.TerminalOptions.ConvertEol, true)
+		options.MacOptionIsMeta = boolOrDefault(input.TerminalOptions.MacOptionIsMeta, true)
+
+		if fontFamily := strings.TrimSpace(input.TerminalOptions.FontFamily); fontFamily != "" {
+			options.FontFamily = fontFamily
+		}
+		if options.FontFamily == "" {
+			options.FontFamily = defaultXtermJSFontFamily
+		}
+
+		if input.TerminalOptions.FontSize >= 1 {
+			options.FontSize = input.TerminalOptions.FontSize
+		} else {
+			options.FontSize = defaultXtermJSFontSize
+		}
+
+		if input.TerminalOptions.Scrollback != nil && *input.TerminalOptions.Scrollback >= 0 {
+			options.Scrollback = intPtr(*input.TerminalOptions.Scrollback)
+		} else {
+			options.Scrollback = intPtr(defaultXtermJSScrollback)
+		}
+
+		theme, err := normalizeThemeConfig(input.TerminalOptions.Theme)
+		if err != nil {
+			return XtermJSSettings{}, err
+		}
+		options.Theme = theme
+
+		normalized.TerminalOptions = &options
+	}
+
+	if input.TerminalPadding != nil && *input.TerminalPadding >= 0 {
+		normalized.TerminalPadding = intPtr(*input.TerminalPadding)
+	}
+	normalized.TransparentBackground = input.TransparentBackground
+	normalized.CustomCss = input.CustomCss
+
+	return normalized, nil
+}
+
+func normalizeThemeConfig(input *ThemeConfig) (*ThemeConfig, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	normalized := &ThemeConfig{
+		Foreground:                  cleanThemeColor(input.Foreground),
+		Background:                  cleanThemeColor(input.Background),
+		Cursor:                      cleanThemeColor(input.Cursor),
+		CursorAccent:                cleanThemeColor(input.CursorAccent),
+		SelectionForeground:         cleanThemeColor(input.SelectionForeground),
+		SelectionBackground:         cleanThemeColor(input.SelectionBackground),
+		SelectionInactiveBackground: cleanThemeColor(input.SelectionInactiveBackground),
+		Black:                       cleanThemeColor(input.Black),
+		Red:                         cleanThemeColor(input.Red),
+		Green:                       cleanThemeColor(input.Green),
+		Yellow:                      cleanThemeColor(input.Yellow),
+		Blue:                        cleanThemeColor(input.Blue),
+		Magenta:                     cleanThemeColor(input.Magenta),
+		Cyan:                        cleanThemeColor(input.Cyan),
+		White:                       cleanThemeColor(input.White),
+		BrightBlack:                 cleanThemeColor(input.BrightBlack),
+		BrightRed:                   cleanThemeColor(input.BrightRed),
+		BrightGreen:                 cleanThemeColor(input.BrightGreen),
+		BrightYellow:                cleanThemeColor(input.BrightYellow),
+		BrightBlue:                  cleanThemeColor(input.BrightBlue),
+		BrightMagenta:               cleanThemeColor(input.BrightMagenta),
+		BrightCyan:                  cleanThemeColor(input.BrightCyan),
+		BrightWhite:                 cleanThemeColor(input.BrightWhite),
+	}
+
+	if len(input.ExtendedAnsi) > 0 {
+		normalized.ExtendedAnsi = make([]string, 0, len(input.ExtendedAnsi))
+		for _, entry := range input.ExtendedAnsi {
+			trimmed := strings.TrimSpace(entry)
+			if trimmed == "" {
+				return nil, errors.New("extendedAnsi must not contain empty strings")
+			}
+			normalized.ExtendedAnsi = append(normalized.ExtendedAnsi, trimmed)
+		}
+	}
+
+	if themeIsEmpty(normalized) {
+		return nil, nil
+	}
+
+	return normalized, nil
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func intPtr(value int) *int {
+	return &value
+}
+
+func boolOrDefault(value *bool, defaultValue bool) *bool {
+	if value == nil {
+		return boolPtr(defaultValue)
+	}
+	return boolPtr(*value)
+}
+
+func cleanThemeColor(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	return trimmed
+}
+
+func themeIsEmpty(theme *ThemeConfig) bool {
+	if theme == nil {
+		return true
+	}
+
+	return theme.Foreground == "" &&
+		theme.Background == "" &&
+		theme.Cursor == "" &&
+		theme.CursorAccent == "" &&
+		theme.SelectionForeground == "" &&
+		theme.SelectionBackground == "" &&
+		theme.SelectionInactiveBackground == "" &&
+		theme.Black == "" &&
+		theme.Red == "" &&
+		theme.Green == "" &&
+		theme.Yellow == "" &&
+		theme.Blue == "" &&
+		theme.Magenta == "" &&
+		theme.Cyan == "" &&
+		theme.White == "" &&
+		theme.BrightBlack == "" &&
+		theme.BrightRed == "" &&
+		theme.BrightGreen == "" &&
+		theme.BrightYellow == "" &&
+		theme.BrightBlue == "" &&
+		theme.BrightMagenta == "" &&
+		theme.BrightCyan == "" &&
+		theme.BrightWhite == "" &&
+		len(theme.ExtendedAnsi) == 0
+}

--- a/api/admin/settings_xtermjs_test.go
+++ b/api/admin/settings_xtermjs_test.go
@@ -1,0 +1,375 @@
+// Do not use t.Parallel(): config.SetDb mutates package-global state.
+package admin
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/komari-monitor/komari/cmd/flags"
+	"github.com/komari-monitor/komari/config"
+	"github.com/komari-monitor/komari/database/dbcore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var xtermJSAuditDBOnce sync.Once
+
+type xtermJSAPIResponse struct {
+	Status  string          `json:"status"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+func ensureXtermJSAuditDB() {
+	xtermJSAuditDBOnce.Do(func() {
+		flags.DatabaseType = "sqlite"
+		flags.DatabaseFile = "file:xtermjs_audit?mode=memory&cache=shared"
+		_ = dbcore.GetDBInstance()
+	})
+}
+
+func setupXtermJSTestDB(t *testing.T) (*gorm.DB, *sql.DB) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+
+	testDBName := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	testDSN := fmt.Sprintf("file:%s?mode=memory&cache=shared", testDBName)
+
+	testDB, err := gorm.Open(sqlite.Open(testDSN), &gorm.Config{})
+	require.NoError(t, err)
+
+	sqlDB, err := testDB.DB()
+	require.NoError(t, err)
+
+	// Initialize the shared audit DB first, then restore the per-test config DB.
+	ensureXtermJSAuditDB()
+	config.SetDb(testDB)
+
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+
+	return testDB, sqlDB
+}
+
+func newXtermJSRouter() *gin.Engine {
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("uuid", "test-uuid")
+		c.Next()
+	})
+	router.GET("/xtermjs", GetXtermJSSettings)
+	router.POST("/xtermjs", SetXtermJSSettings)
+	return router
+}
+
+func performXtermJSRequest(t *testing.T, router *gin.Engine, method, target string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req, err := http.NewRequest(method, target, bytes.NewReader(body))
+	require.NoError(t, err)
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func decodeXtermJSResponse(t *testing.T, w *httptest.ResponseRecorder) xtermJSAPIResponse {
+	t.Helper()
+
+	var resp xtermJSAPIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	return resp
+}
+
+func decodeXtermJSSettings(t *testing.T, raw json.RawMessage) XtermJSSettings {
+	t.Helper()
+
+	var settings XtermJSSettings
+	require.NoError(t, json.Unmarshal(raw, &settings))
+	return settings
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestGetXtermJSSettingsReturnsDefaultWhenMissing(t *testing.T) {
+	testDB, _ := setupXtermJSTestDB(t)
+	router := newXtermJSRouter()
+
+	w := performXtermJSRequest(t, router, http.MethodGet, "/xtermjs", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	resp := decodeXtermJSResponse(t, w)
+	assert.Equal(t, "success", resp.Status)
+	assert.Empty(t, resp.Message)
+
+	got := decodeXtermJSSettings(t, resp.Data)
+	expected := defaultXtermJSSettings()
+	assert.Equal(t, expected, got)
+
+	var stored config.ConfigItem
+	require.NoError(t, testDB.First(&stored, "key = ?", config.XtermjsSettingsKey).Error)
+
+	var persisted XtermJSSettings
+	require.NoError(t, json.Unmarshal([]byte(stored.Value), &persisted))
+	assert.Equal(t, expected, persisted)
+}
+
+func TestXtermJSSettingsRoundTripAndThemeVariants(t *testing.T) {
+	t.Run("full config round trip", func(t *testing.T) {
+		setupXtermJSTestDB(t)
+		router := newXtermJSRouter()
+
+		input := XtermJSSettings{
+			TerminalOptions: &TerminalOptions{
+				CursorBlink:     ptr(false),
+				ConvertEol:      ptr(false),
+				FontFamily:      "JetBrains Mono",
+				FontSize:        18,
+				MacOptionIsMeta: ptr(false),
+				Scrollback:      ptr(9000),
+				Theme: &ThemeConfig{
+					Foreground:          "#f8f8f2",
+					Background:          "#282a36",
+					Cursor:              "#f8f8f2",
+					SelectionBackground: "#44475a",
+					Blue:                "#6272a4",
+					ExtendedAnsi:        []string{"#111111", "#222222"},
+				},
+			},
+			TerminalPadding:       ptr(20),
+			TransparentBackground: true,
+			CustomCss:             "body { color: red; }",
+		}
+
+		body, err := json.Marshal(input)
+		require.NoError(t, err)
+
+		w := performXtermJSRequest(t, router, http.MethodPost, "/xtermjs", body)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		resp := decodeXtermJSResponse(t, w)
+		assert.Equal(t, "success", resp.Status)
+		assert.Equal(t, "settings saved", resp.Message)
+
+		getResp := decodeXtermJSResponse(t, performXtermJSRequest(t, router, http.MethodGet, "/xtermjs", nil))
+		got := decodeXtermJSSettings(t, getResp.Data)
+		assert.Equal(t, input, got)
+	})
+
+	t.Run("theme null stays null", func(t *testing.T) {
+		setupXtermJSTestDB(t)
+		router := newXtermJSRouter()
+
+		body := []byte(`{"terminalOptions":{"cursorBlink":true,"convertEol":true,"fontFamily":"JetBrains Mono","fontSize":17,"macOptionIsMeta":true,"scrollback":1000,"theme":null},"terminalPadding":16,"transparentBackground":false,"customCss":"."}`)
+		w := performXtermJSRequest(t, router, http.MethodPost, "/xtermjs", body)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		got := decodeXtermJSSettings(t, decodeXtermJSResponse(t, performXtermJSRequest(t, router, http.MethodGet, "/xtermjs", nil)).Data)
+		require.NotNil(t, got.TerminalOptions)
+		assert.Nil(t, got.TerminalOptions.Theme)
+	})
+
+	t.Run("terminalOptions null uses defaults", func(t *testing.T) {
+		setupXtermJSTestDB(t)
+		router := newXtermJSRouter()
+
+		body := []byte(`{"terminalOptions":null,"terminalPadding":24,"transparentBackground":true,"customCss":"body { background: black; }"}`)
+		w := performXtermJSRequest(t, router, http.MethodPost, "/xtermjs", body)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		got := decodeXtermJSSettings(t, decodeXtermJSResponse(t, performXtermJSRequest(t, router, http.MethodGet, "/xtermjs", nil)).Data)
+		expected := defaultXtermJSSettings()
+		expected.TerminalPadding = ptr(24)
+		expected.TransparentBackground = true
+		expected.CustomCss = "body { background: black; }"
+		assert.Equal(t, expected, got)
+	})
+}
+
+func TestXtermJSSettingsUnknownThemeFieldsAreDropped(t *testing.T) {
+	testDB, _ := setupXtermJSTestDB(t)
+	router := newXtermJSRouter()
+
+	body := []byte(`{"terminalOptions":{"fontFamily":"JetBrains Mono","fontSize":16,"theme":{"foreground":"#ffffff","unknownField":"keep-out","extendedAnsi":["#111111"]}}}`)
+	w := performXtermJSRequest(t, router, http.MethodPost, "/xtermjs", body)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	resp := decodeXtermJSResponse(t, w)
+	assert.Equal(t, "success", resp.Status)
+
+	getResp := decodeXtermJSResponse(t, performXtermJSRequest(t, router, http.MethodGet, "/xtermjs", nil))
+	got := decodeXtermJSSettings(t, getResp.Data)
+	require.NotNil(t, got.TerminalOptions)
+	require.NotNil(t, got.TerminalOptions.Theme)
+	assert.Equal(t, "#ffffff", got.TerminalOptions.Theme.Foreground)
+
+	var stored config.ConfigItem
+	require.NoError(t, testDB.First(&stored, "key = ?", config.XtermjsSettingsKey).Error)
+	assert.NotContains(t, stored.Value, "unknownField")
+}
+
+func TestXtermJSSettingsValidationAndFallbacks(t *testing.T) {
+	t.Run("extendedAnsi and body validation", func(t *testing.T) {
+		cases := []struct {
+			name string
+			body []byte
+		}{
+			{
+				name: "empty string",
+				body: []byte(`{"terminalOptions":{"theme":{"extendedAnsi":[""]}}}`),
+			},
+			{
+				name: "space string",
+				body: []byte(`{"terminalOptions":{"theme":{"extendedAnsi":["   "]}}}`),
+			},
+			{
+				name: "illegal type",
+				body: []byte(`{"terminalOptions":{"theme":{"extendedAnsi":[1]}}}`),
+			},
+			{
+				name: "invalid json",
+				body: []byte(`{"terminalOptions":`),
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				setupXtermJSTestDB(t)
+				router := newXtermJSRouter()
+
+				w := performXtermJSRequest(t, router, http.MethodPost, "/xtermjs", tc.body)
+				require.Equal(t, http.StatusBadRequest, w.Code)
+
+				resp := decodeXtermJSResponse(t, w)
+				assert.Equal(t, "error", resp.Status)
+				assert.NotEmpty(t, resp.Message)
+			})
+		}
+	})
+
+	t.Run("fallbacks are normalized on save and read", func(t *testing.T) {
+		testDB, _ := setupXtermJSTestDB(t)
+		router := newXtermJSRouter()
+
+		neg := -1
+		body, err := json.Marshal(XtermJSSettings{
+			TerminalOptions: &TerminalOptions{
+				CursorBlink:     ptr(true),
+				ConvertEol:      ptr(true),
+				FontFamily:      "   ",
+				FontSize:        0,
+				MacOptionIsMeta: ptr(true),
+				Scrollback:      &neg,
+				Theme: &ThemeConfig{
+					Foreground: "   ",
+				},
+			},
+			TerminalPadding:       &neg,
+			TransparentBackground: true,
+			CustomCss:             "body { color: blue; }",
+		})
+		require.NoError(t, err)
+
+		w := performXtermJSRequest(t, router, http.MethodPost, "/xtermjs", body)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		got := decodeXtermJSSettings(t, decodeXtermJSResponse(t, performXtermJSRequest(t, router, http.MethodGet, "/xtermjs", nil)).Data)
+		expected := defaultXtermJSSettings()
+		expected.TransparentBackground = true
+		expected.CustomCss = "body { color: blue; }"
+		assert.Equal(t, expected, got)
+
+		var stored config.ConfigItem
+		require.NoError(t, testDB.First(&stored, "key = ?", config.XtermjsSettingsKey).Error)
+		var persisted XtermJSSettings
+		require.NoError(t, json.Unmarshal([]byte(stored.Value), &persisted))
+		assert.Equal(t, expected, persisted)
+	})
+
+	t.Run("corrupt JSON is repaired on get", func(t *testing.T) {
+		testDB, _ := setupXtermJSTestDB(t)
+		router := newXtermJSRouter()
+
+		raw := `{"terminalOptions":`
+		require.NoError(t, testDB.Create(&config.ConfigItem{
+			Key:   config.XtermjsSettingsKey,
+			Value: raw,
+		}).Error)
+
+		w := performXtermJSRequest(t, router, http.MethodGet, "/xtermjs", nil)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		got := decodeXtermJSSettings(t, decodeXtermJSResponse(t, w).Data)
+		expected := defaultXtermJSSettings()
+		assert.Equal(t, expected, got)
+
+		var stored config.ConfigItem
+		require.NoError(t, testDB.First(&stored, "key = ?", config.XtermjsSettingsKey).Error)
+		var persisted XtermJSSettings
+		require.NoError(t, json.Unmarshal([]byte(stored.Value), &persisted))
+		assert.Equal(t, expected, persisted)
+	})
+}
+
+func TestXtermJSSettingsNormalizesSeededLegacyConfig(t *testing.T) {
+	testDB, _ := setupXtermJSTestDB(t)
+	router := newXtermJSRouter()
+
+	seeded := `{"terminalOptions":{"cursorBlink":true,"convertEol":true,"fontFamily":"JetBrains Mono","fontSize":0,"macOptionIsMeta":true,"scrollback":1200,"theme":null},"terminalPadding":12,"transparentBackground":true,"customCss":"seeded"}`
+	require.NoError(t, testDB.Create(&config.ConfigItem{
+		Key:   config.XtermjsSettingsKey,
+		Value: seeded,
+	}).Error)
+
+	w := performXtermJSRequest(t, router, http.MethodGet, "/xtermjs", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	got := decodeXtermJSSettings(t, decodeXtermJSResponse(t, w).Data)
+	expected := XtermJSSettings{
+		TerminalOptions: &TerminalOptions{
+			CursorBlink:     ptr(true),
+			ConvertEol:      ptr(true),
+			FontFamily:      "JetBrains Mono",
+			FontSize:        16,
+			MacOptionIsMeta: ptr(true),
+			Scrollback:      ptr(1200),
+			Theme:           nil,
+		},
+		TerminalPadding:       ptr(12),
+		TransparentBackground: true,
+		CustomCss:             "seeded",
+	}
+	assert.Equal(t, expected, got)
+}
+
+func TestXtermJSSettingsSaveFailureReturns500(t *testing.T) {
+	_, sqlDB := setupXtermJSTestDB(t)
+	router := newXtermJSRouter()
+
+	require.NoError(t, sqlDB.Close())
+
+	body := []byte(`{"terminalOptions":{"fontFamily":"JetBrains Mono","fontSize":16,"theme":null}}`)
+	w := performXtermJSRequest(t, router, http.MethodPost, "/xtermjs", body)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+
+	resp := decodeXtermJSResponse(t, w)
+	assert.Equal(t, "error", resp.Status)
+	assert.Contains(t, resp.Message, "Failed to save settings:")
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -243,6 +243,8 @@ func RunServer() {
 		{
 			settingsGroup.GET("/", admin.GetSettings)
 			settingsGroup.POST("/", admin.EditSettings)
+			settingsGroup.GET("/xtermjs", admin.GetXtermJSSettings)
+			settingsGroup.POST("/xtermjs", admin.SetXtermJSSettings)
 			settingsGroup.POST("/oidc", admin.SetOidcProvider)
 			settingsGroup.GET("/oidc", admin.GetOidcProvider)
 			settingsGroup.POST("/message-sender", admin.SetMessageSenderProvider)

--- a/config/legacy.go
+++ b/config/legacy.go
@@ -77,6 +77,7 @@ const (
 	RecordPreserveTimeKey         = "record_preserve_time"
 	PingRecordPreserveTimeKey     = "ping_record_preserve_time"
 	UpdatedAtKey                  = "updated_at"
+	XtermjsSettingsKey            = "xtermjs_settings"
 )
 
 func (Legacy) TableName() string {


### PR DESCRIPTION
## 添加 XtermJS 配置的 API 持久化接口

详情请见 [Feat/add xtermjs setting](https://github.com/komari-monitor/komari-web/pull/60)

给上述 PR 提供后端配置的 API