### PR TITLE
feat: add client currency code

### DIFF
--- a/database/clients/client.go
+++ b/database/clients/client.go
@@ -210,11 +210,12 @@ func CreateClient() (clientUUID, token string, err error) {
 	clientUUID = uuid.New().String()
 
 	client := models.Client{
-		UUID:      clientUUID,
-		Token:     token,
-		Name:      "client_" + clientUUID[0:8],
-		CreatedAt: models.FromTime(time.Now()),
-		UpdatedAt: models.FromTime(time.Now()),
+		UUID:         clientUUID,
+		Token:        token,
+		Name:         "client_" + clientUUID[0:8],
+		CurrencyCode: "USD",
+		CreatedAt:    models.FromTime(time.Now()),
+		UpdatedAt:    models.FromTime(time.Now()),
 	}
 
 	err = db.Create(&client).Error
@@ -235,11 +236,12 @@ func CreateClientWithName(name string) (clientUUID, token string, err error) {
 	token = utils.GenerateToken()
 	clientUUID = uuid.New().String()
 	client := models.Client{
-		UUID:      clientUUID,
-		Token:     token,
-		Name:      name,
-		CreatedAt: models.FromTime(time.Now()),
-		UpdatedAt: models.FromTime(time.Now()),
+		UUID:         clientUUID,
+		Token:        token,
+		Name:         name,
+		CurrencyCode: "USD",
+		CreatedAt:    models.FromTime(time.Now()),
+		UpdatedAt:    models.FromTime(time.Now()),
 	}
 
 	err = db.Create(&client).Error

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -32,6 +32,7 @@ type Client struct {
 	BillingCycle     int       `json:"billing_cycle"`
 	AutoRenewal      bool      `json:"auto_renewal" gorm:"default:false"` // 是否自动续费
 	Currency         string    `json:"currency" gorm:"type:varchar(20);default:'$'"`
+	CurrencyCode     string    `json:"currency_code" gorm:"type:varchar(10);default:'USD'"`
 	ExpiredAt        LocalTime `json:"expired_at" gorm:"type:timestamp"`
 	Group            string    `json:"group" gorm:"type:varchar(100)"`
 	Tags             string    `json:"tags" gorm:"type:text"` // split by ';'


### PR DESCRIPTION
用于区分不同货币但相同货币符号的情况，比如目前USD、CAD、HKD 都用的$符号