### PR TITLE
fix: 允许在开发版使用不安全会话 cookies

### DIFF
--- a/web/api/public/login.go
+++ b/web/api/public/login.go
@@ -8,6 +8,7 @@ import (
 	"github.com/komari-monitor/komari/database/accounts"
 	"github.com/komari-monitor/komari/database/auditlog"
 	"github.com/komari-monitor/komari/pkg/config"
+	"github.com/komari-monitor/komari/utils"
 	"github.com/komari-monitor/komari/web/api"
 
 	"github.com/gin-gonic/gin"
@@ -27,7 +28,7 @@ func setSessionCookie(c *gin.Context, value string, maxAge int) {
 		Value:    value,
 		Path:     "/",
 		MaxAge:   maxAge,
-		Secure:   true,
+		Secure:   utils.GetScheme(c) == "https" || utils.CurrentVersion != "dev",
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	})

--- a/web/api/public/login_test.go
+++ b/web/api/public/login_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/komari-monitor/komari/database/accounts"
+	"github.com/komari-monitor/komari/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -98,4 +100,38 @@ func TestLogin(t *testing.T) {
 	// 清除测试数据
 	accounts.DeleteAccountByUsername("testuser")
 	accounts.DeleteAllSessions()
+}
+
+func TestSessionCookieIsSecureOnHTTPByDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	original := utils.CurrentVersion
+	utils.CurrentVersion = "0.0.1"
+	defer func() {
+		utils.CurrentVersion = original
+	}()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "http://example.test/login", nil)
+
+	setSessionCookie(c, "test-session", sessionCookieMaxAge)
+
+	assert.Contains(t, strings.Join(w.Header().Values("Set-Cookie"), "\n"), "Secure")
+}
+
+func TestSessionCookieIsNotSecureOnHTTPWhenOverrideEnabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	original := utils.CurrentVersion
+	utils.CurrentVersion = "dev"
+	defer func() {
+		utils.CurrentVersion = original
+	}()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "http://example.test/login", nil)
+
+	setSessionCookie(c, "test-session", sessionCookieMaxAge)
+
+	assert.NotContains(t, strings.Join(w.Header().Values("Set-Cookie"), "\n"), "Secure")
 }


### PR DESCRIPTION
f86803feff3c5deb99055379d182c680faffdc21 给 cookies 设置了 `Secure: true` 导致本地 HTTP 开发时登陆成功后, 浏览器却不会发送饼干, 从而无法进入管理页面

改进逻辑如下:
1. 如果 HTTPS 则 `Secure: true`
2. 如果 HTTP 且是 dev build (`CurrentVersion=dev`) 则 `Secure: false`
3. 其余一律 `Secure: true`

`CurrentVersion=dev` 在 `development.yml` workflow 也有用到所以就直接拿来用了