### PR TITLE
feat: add network test rpc protocol structs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Codex Development Rules for komari
+
+This repository is a fork of `komari-monitor/komari`. The current development goal is to add network test, mesh trace, and topology features without breaking the existing probe baseline functionality.
+
+## Scope and Change Discipline
+
+- Make changes in small, reviewable steps. Do not implement a complete large feature in a single task.
+- Prefer the existing architecture, naming, package structure, and JSON-RPC style.
+- Do not modify modules unrelated to the current task, including OAuth, basic CPU/memory reporting, heartbeat detection, login authentication, and existing WebSocket reconnect logic.
+- Do not create commits automatically. After making changes, stop and wait for manual review.
+
+## Data and API Conventions
+
+- All new JSON fields must use `snake_case`.
+- Keep JSON-RPC behavior and naming consistent with existing protocol conventions.
+
+## Go Code Rules
+
+- Run `gofmt` on all modified Go files.
+- When executing system commands, do not use shell string concatenation.
+- Do not use `sh -c`, `cmd /c`, or equivalent shell wrappers for user-controllable strings.
+- Use `exec.CommandContext` with explicit argument arrays for command execution.
+
+## Agent Executor Requirements
+
+Any task involving Agent executors must include:
+
+- Timeout handling.
+- Output size limits.
+- Target host validation.
+- Concurrency limits.
+
+## Master Scheduler Requirements
+
+Any task involving the Master scheduler must include:
+
+- A global concurrency limit.
+- A per-Agent concurrency limit.
+- Task status storage or an in-memory store abstraction.
+- No long-running synchronous blocking of HTTP or RPC requests.
+
+## Testing Baseline
+
+- The local `go test ./...` baseline may fail because of an existing unrelated panic in `web/oauth/factory_test.go`.
+- Do not fix that unrelated issue unless explicitly asked.
+- For the current stage, only require these commands to pass:
+  - `go test ./protocol/v2 ./pkg/rpc`
+
+## Task Completion Report
+
+At the end of every task, report:
+
+- Modified file list.
+- Test command.
+- Test result.
+- Whether any unfinished items remain.

--- a/protocol/v2/networktest.go
+++ b/protocol/v2/networktest.go
@@ -1,0 +1,124 @@
+package v2
+
+import "encoding/json"
+
+const (
+	MethodNetworkTestNextTrace       = "networkTest.nextTrace"
+	MethodNetworkTestIperf3          = "networkTest.iperf3"
+	MethodNetworkTestMeshTrace       = "networkTest.meshTrace"
+	MethodNetworkTestGetMeshTraceJob = "networkTest.getMeshTraceJob"
+)
+
+type IPFamily string
+
+const (
+	IPFamilyAuto IPFamily = "auto"
+	IPFamilyIPv4 IPFamily = "ipv4"
+	IPFamilyIPv6 IPFamily = "ipv6"
+)
+
+type TraceProtocol string
+
+const (
+	TraceProtocolICMP TraceProtocol = "icmp"
+	TraceProtocolTCP  TraceProtocol = "tcp"
+	TraceProtocolUDP  TraceProtocol = "udp"
+)
+
+type MeshMode string
+
+const (
+	MeshModeAllToAll MeshMode = "all_to_all"
+	MeshModeOneToAll MeshMode = "one_to_all"
+	MeshModePairs    MeshMode = "pairs"
+)
+
+type NodeEndpoint struct {
+	NodeID string   `json:"node_id"`
+	Name   string   `json:"name"`
+	Host   string   `json:"host"`
+	Family IPFamily `json:"ip_family"`
+}
+
+type NextTraceParams struct {
+	TaskID     string        `json:"task_id"`
+	SourceID   string        `json:"source_id"`
+	TargetID   string        `json:"target_id"`
+	TargetHost string        `json:"target_host"`
+	IPFamily   IPFamily      `json:"ip_family"`
+	Protocol   TraceProtocol `json:"protocol"`
+	MaxHops    int           `json:"max_hops"`
+	TimeoutMs  int           `json:"timeout_ms"`
+	RawOutput  bool          `json:"raw_output"`
+}
+
+type NextTraceResult struct {
+	TaskID     string          `json:"task_id"`
+	SourceID   string          `json:"source_id"`
+	TargetID   string          `json:"target_id"`
+	TargetHost string          `json:"target_host"`
+	IPFamily   IPFamily        `json:"ip_family"`
+	Protocol   TraceProtocol   `json:"protocol"`
+	StartedAt  string          `json:"started_at"`
+	FinishedAt string          `json:"finished_at"`
+	DurationMs int             `json:"duration_ms"`
+	OK         bool            `json:"ok"`
+	Error      string          `json:"error"`
+	Summary    TraceSummary    `json:"summary"`
+	Hops       []TraceHop      `json:"hops"`
+	Raw        json.RawMessage `json:"raw"`
+	RawText    string          `json:"raw_text"`
+	ExitCode   int             `json:"exit_code"`
+	Truncated  bool            `json:"truncated"`
+}
+
+type TraceSummary struct {
+	HopCount   int     `json:"hop_count"`
+	Reached    bool    `json:"reached"`
+	PacketLoss float64 `json:"packet_loss"`
+	RTTMs      float64 `json:"rtt_ms"`
+}
+
+type TraceHop struct {
+	Hop      int     `json:"hop"`
+	Host     string  `json:"host"`
+	IP       string  `json:"ip"`
+	RTTMs    float64 `json:"rtt_ms"`
+	Loss     float64 `json:"loss"`
+	ASN      string  `json:"asn"`
+	Location string  `json:"location"`
+}
+
+type MeshTraceParams struct {
+	SourceNodeIDs  []string      `json:"source_node_ids"`
+	TargetNodeIDs  []string      `json:"target_node_ids"`
+	Mode           MeshMode      `json:"mode"`
+	IPFamily       IPFamily      `json:"ip_family"`
+	Protocol       TraceProtocol `json:"protocol"`
+	MaxHops        int           `json:"max_hops"`
+	TimeoutMs      int           `json:"timeout_ms"`
+	MaxConcurrency int           `json:"max_concurrency"`
+	PerAgentLimit  int           `json:"per_agent_limit"`
+}
+
+type MeshTraceAccepted struct {
+	JobID          string `json:"job_id"`
+	Status         string `json:"status"`
+	TotalPairs     int    `json:"total_pairs"`
+	AcceptedAt     string `json:"accepted_at"`
+	PollIntervalMs int    `json:"poll_interval_ms"`
+}
+
+type MeshTraceJobSnapshot struct {
+	JobID      string            `json:"job_id"`
+	Status     string            `json:"status"`
+	Total      int               `json:"total"`
+	Done       int               `json:"done"`
+	Failed     int               `json:"failed"`
+	Running    int               `json:"running"`
+	Results    []NextTraceResult `json:"results"`
+	StartedAt  string            `json:"started_at"`
+	UpdatedAt  string            `json:"updated_at"`
+	FinishedAt string            `json:"finished_at"`
+	Error      string            `json:"error"`
+}

--- a/protocol/v2/networktest_test.go
+++ b/protocol/v2/networktest_test.go
@@ -1,0 +1,317 @@
+package v2
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNetworkTestMethodConstants(t *testing.T) {
+	tests := map[string]string{
+		MethodNetworkTestNextTrace:       "networkTest.nextTrace",
+		MethodNetworkTestIperf3:          "networkTest.iperf3",
+		MethodNetworkTestMeshTrace:       "networkTest.meshTrace",
+		MethodNetworkTestGetMeshTraceJob: "networkTest.getMeshTraceJob",
+	}
+
+	for got, want := range tests {
+		if got != want {
+			t.Fatalf("method constant = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestNextTraceParamsJSON(t *testing.T) {
+	params := NextTraceParams{
+		TaskID:     "trace-1",
+		SourceID:   "agent-a",
+		TargetID:   "agent-b",
+		TargetHost: "203.0.113.10",
+		IPFamily:   IPFamilyIPv4,
+		Protocol:   TraceProtocolICMP,
+		MaxHops:    30,
+		TimeoutMs:  5000,
+		RawOutput:  true,
+	}
+
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertJSONKeys(t, data, []string{
+		"task_id",
+		"source_id",
+		"target_id",
+		"target_host",
+		"ip_family",
+		"protocol",
+		"max_hops",
+		"timeout_ms",
+		"raw_output",
+	})
+	assertNoCamelCaseKeys(t, data)
+
+	var decoded NextTraceParams
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(decoded, params) {
+		t.Fatalf("decoded params = %#v, want %#v", decoded, params)
+	}
+}
+
+func TestNextTraceResultJSON(t *testing.T) {
+	result := NextTraceResult{
+		TaskID:     "trace-1",
+		SourceID:   "agent-a",
+		TargetID:   "agent-b",
+		TargetHost: "203.0.113.10",
+		IPFamily:   IPFamilyIPv4,
+		Protocol:   TraceProtocolICMP,
+		StartedAt:  "2026-06-05T10:00:00Z",
+		FinishedAt: "2026-06-05T10:00:01Z",
+		DurationMs: 1000,
+		OK:         true,
+		Error:      "",
+		Summary: TraceSummary{
+			HopCount:   2,
+			Reached:    true,
+			PacketLoss: 0,
+			RTTMs:      12.5,
+		},
+		Hops: []TraceHop{
+			{Hop: 1, Host: "router", IP: "192.0.2.1", RTTMs: 1.2, Loss: 0, ASN: "AS64500", Location: "lab"},
+			{Hop: 2, Host: "target", IP: "203.0.113.10", RTTMs: 12.5, Loss: 0, ASN: "AS64501", Location: "edge"},
+		},
+		Raw:       json.RawMessage(`{"parser":"nexttrace"}`),
+		RawText:   "raw trace text",
+		ExitCode:  0,
+		Truncated: false,
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertJSONKeys(t, data, []string{
+		"task_id",
+		"source_id",
+		"target_id",
+		"target_host",
+		"ip_family",
+		"protocol",
+		"started_at",
+		"finished_at",
+		"duration_ms",
+		"ok",
+		"error",
+		"summary",
+		"hops",
+		"raw",
+		"raw_text",
+		"exit_code",
+		"truncated",
+	})
+	assertJSONKeysAt(t, data, "summary", []string{"hop_count", "reached", "packet_loss", "rtt_ms"})
+	assertJSONKeysAt(t, data, "hops.0", []string{"hop", "host", "ip", "rtt_ms", "loss", "asn", "location"})
+	assertNoCamelCaseKeys(t, data)
+
+	var decoded NextTraceResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(decoded, result) {
+		t.Fatalf("decoded result = %#v, want %#v", decoded, result)
+	}
+}
+
+func TestMeshTraceParamsJSON(t *testing.T) {
+	params := MeshTraceParams{
+		SourceNodeIDs:  []string{"agent-a"},
+		TargetNodeIDs:  []string{"agent-b", "agent-c"},
+		Mode:           MeshModeOneToAll,
+		IPFamily:       IPFamilyIPv6,
+		Protocol:       TraceProtocolTCP,
+		MaxHops:        20,
+		TimeoutMs:      8000,
+		MaxConcurrency: 4,
+		PerAgentLimit:  2,
+	}
+
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertJSONKeys(t, data, []string{
+		"source_node_ids",
+		"target_node_ids",
+		"mode",
+		"ip_family",
+		"protocol",
+		"max_hops",
+		"timeout_ms",
+		"max_concurrency",
+		"per_agent_limit",
+	})
+	assertNoCamelCaseKeys(t, data)
+
+	var decoded MeshTraceParams
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(decoded, params) {
+		t.Fatalf("decoded params = %#v, want %#v", decoded, params)
+	}
+}
+
+func TestMeshTraceJobSnapshotJSON(t *testing.T) {
+	snapshot := MeshTraceJobSnapshot{
+		JobID:   "mesh-1",
+		Status:  "running",
+		Total:   2,
+		Done:    1,
+		Failed:  0,
+		Running: 1,
+		Results: []NextTraceResult{
+			{
+				TaskID:     "trace-1",
+				SourceID:   "agent-a",
+				TargetID:   "agent-b",
+				TargetHost: "203.0.113.10",
+				IPFamily:   IPFamilyIPv4,
+				Protocol:   TraceProtocolUDP,
+				StartedAt:  "2026-06-05T10:00:00Z",
+				FinishedAt: "2026-06-05T10:00:01Z",
+				DurationMs: 1000,
+				OK:         false,
+				Error:      "timeout",
+				Summary:    TraceSummary{HopCount: 0, Reached: false, PacketLoss: 1, RTTMs: 0},
+				Hops:       []TraceHop{},
+				Raw:        json.RawMessage(`null`),
+				RawText:    "",
+				ExitCode:   1,
+				Truncated:  false,
+			},
+		},
+		StartedAt:  "2026-06-05T10:00:00Z",
+		UpdatedAt:  "2026-06-05T10:00:01Z",
+		FinishedAt: "",
+		Error:      "",
+	}
+
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertJSONKeys(t, data, []string{
+		"job_id",
+		"status",
+		"total",
+		"done",
+		"failed",
+		"running",
+		"results",
+		"started_at",
+		"updated_at",
+		"finished_at",
+		"error",
+	})
+	assertJSONKeysAt(t, data, "results.0", []string{"task_id", "source_id", "target_id", "target_host"})
+	assertNoCamelCaseKeys(t, data)
+
+	var decoded MeshTraceJobSnapshot
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(decoded, snapshot) {
+		t.Fatalf("decoded snapshot = %#v, want %#v", decoded, snapshot)
+	}
+}
+
+func assertJSONKeys(t *testing.T, data []byte, keys []string) {
+	t.Helper()
+
+	var object map[string]any
+	if err := json.Unmarshal(data, &object); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, key := range keys {
+		if _, ok := object[key]; !ok {
+			t.Fatalf("missing JSON key %q in %s", key, data)
+		}
+	}
+}
+
+func assertJSONKeysAt(t *testing.T, data []byte, path string, keys []string) {
+	t.Helper()
+
+	var root any
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatal(err)
+	}
+
+	object := jsonObjectAt(t, root, path)
+	for _, key := range keys {
+		if _, ok := object[key]; !ok {
+			t.Fatalf("missing JSON key %q at %q in %s", key, path, data)
+		}
+	}
+}
+
+func assertNoCamelCaseKeys(t *testing.T, data []byte) {
+	t.Helper()
+
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		t.Fatal(err)
+	}
+
+	var walk func(any)
+	walk = func(current any) {
+		switch typed := current.(type) {
+		case map[string]any:
+			for key, next := range typed {
+				if strings.ContainsAny(key, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+					t.Fatalf("JSON key %q contains uppercase characters in %s", key, data)
+				}
+				walk(next)
+			}
+		case []any:
+			for _, next := range typed {
+				walk(next)
+			}
+		}
+	}
+	walk(value)
+}
+
+func jsonObjectAt(t *testing.T, root any, path string) map[string]any {
+	t.Helper()
+
+	current := root
+	for _, part := range strings.Split(path, ".") {
+		switch typed := current.(type) {
+		case map[string]any:
+			current = typed[part]
+		case []any:
+			if part != "0" {
+				t.Fatalf("unsupported array path segment %q", part)
+			}
+			current = typed[0]
+		default:
+			t.Fatalf("path %q reached non-container value %#v", path, current)
+		}
+	}
+
+	object, ok := current.(map[string]any)
+	if !ok {
+		t.Fatalf("path %q is not a JSON object: %#v", path, current)
+	}
+	return object
+}


### PR DESCRIPTION
## Summary

Adds JSON-RPC v2 protocol structs and method constants for the planned network test feature set:

- networkTest.nextTrace
- networkTest.iperf3
- networkTest.meshTrace
- networkTest.getMeshTraceJob

The new structs cover:

- Master -> Agent single nexttrace execution
- Web -> Master mesh trace job creation
- Web -> Master mesh trace job polling/snapshot

## Scope

This PR only modifies protocol definitions and tests.

It does not modify:

- Agent WebSocket handling
- Master RPC registration
- Web UI
- OAuth
- Database
- Heartbeat
- CPU/memory reporting

## Tests

```bash
go test ./protocol/v2 ./pkg/rpc