### PR TITLE
fix: 流量报告功能补正

### DIFF
--- a/database/clients/report.go
+++ b/database/clients/report.go
@@ -2,16 +2,57 @@ package clients
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
-	"github.com/komari-monitor/komari/protocol/v1"
 	"github.com/komari-monitor/komari/database/dbcore"
 	"github.com/komari-monitor/komari/database/models"
+	v1 "github.com/komari-monitor/komari/protocol/v1"
 
 	"gorm.io/gorm"
 )
+
+var reportSaveLocks sync.Map
+
+func getReportSaveLock(clientUUID string) *sync.Mutex {
+	lock, _ := reportSaveLocks.LoadOrStore(clientUUID, &sync.Mutex{})
+	return lock.(*sync.Mutex)
+}
+
+func computeTrafficDelta(current, previous int64) int64 {
+	if previous < 0 {
+		return 0
+	}
+	if current >= previous {
+		return current - previous
+	}
+	// Counter reset or reboot: treat the new counter value as traffic since reset.
+	return current
+}
+
+func getLatestTrafficRecord(tx *gorm.DB, clientUUID string) (*models.Record, error) {
+	var record models.Record
+	err := tx.Where("client = ?", clientUUID).Order("time DESC").First(&record).Error
+	if err == nil {
+		return &record, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	err = tx.Table("records_long_term").Where("client = ?", clientUUID).Order("time DESC").First(&record).Error
+	if err == nil {
+		return &record, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	return nil, nil
+}
 
 // Report 表示客户端报告数据
 // SaveReport 保存报告数据
@@ -139,9 +180,12 @@ func ReportVerify(report v1.Report) error {
 // SaveClientReport 保存客户端报告到 Record 表
 func SaveClientReport(clientUUID string, report v1.Report) (err error) {
 	db := dbcore.GetDBInstance()
+	lock := getReportSaveLock(clientUUID)
+	lock.Lock()
+	defer lock.Unlock()
 
 	if err := ReportVerify(report); err != nil {
-		return fmt.Errorf("failed to save Record: %v", err)
+		return fmt.Errorf("failed to save Record: %w", err)
 	}
 
 	// 保存GPU详细记录到独立表
@@ -159,7 +203,7 @@ func SaveClientReport(clientUUID string, report v1.Report) (err error) {
 				Temperature: gpu.Temperature,
 			}
 			if err := db.Create(&gpuRecord).Error; err != nil {
-				return fmt.Errorf("failed to save GPU record: %v", err)
+				return fmt.Errorf("failed to save GPU record: %w", err)
 			}
 		}
 	}
@@ -187,6 +231,8 @@ func SaveClientReport(clientUUID string, report v1.Report) (err error) {
 		NetOut:         report.Network.Up,
 		NetTotalUp:     report.Network.TotalUp,
 		NetTotalDown:   report.Network.TotalDown,
+		TrafficUp:      0,
+		TrafficDown:    0,
 		Process:        report.Process,
 		Connections:    report.Connections.TCP,
 		ConnectionsUdp: report.Connections.UDP,
@@ -195,9 +241,18 @@ func SaveClientReport(clientUUID string, report v1.Report) (err error) {
 
 	// 使用事务确保 Record 和 ClientsInfo 一致性
 	err = db.Transaction(func(tx *gorm.DB) error {
+		previous, err := getLatestTrafficRecord(tx, clientUUID)
+		if err != nil {
+			return fmt.Errorf("failed to load previous Record: %w", err)
+		}
+		if previous != nil {
+			Record.TrafficUp = computeTrafficDelta(report.Network.TotalUp, previous.NetTotalUp)
+			Record.TrafficDown = computeTrafficDelta(report.Network.TotalDown, previous.NetTotalDown)
+		}
+
 		// 保存 Record
 		if err := tx.Create(&Record).Error; err != nil {
-			return fmt.Errorf("failed to save Record: %v", err)
+			return fmt.Errorf("failed to save Record: %w", err)
 		}
 		return nil
 	})

--- a/database/clients/report_test.go
+++ b/database/clients/report_test.go
@@ -1,0 +1,82 @@
+package clients
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeTrafficDeltaHandlesZeroAndReset(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  int64
+		previous int64
+		want     int64
+	}{
+		{name: "previous zero counts current delta", current: 120, previous: 0, want: 120},
+		{name: "monotonic counter uses difference", current: 250, previous: 200, want: 50},
+		{name: "counter reset uses current", current: 15, previous: 250, want: 15},
+		{name: "negative previous remains guarded", current: 15, previous: -1, want: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, computeTrafficDelta(test.current, test.previous))
+		})
+	}
+}
+
+func TestReportSaveLockSerializesSameClient(t *testing.T) {
+	clientUUID := "client-lock-same"
+	lock := getReportSaveLock(clientUUID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	acquired := make(chan struct{})
+	go func() {
+		secondLock := getReportSaveLock(clientUUID)
+		secondLock.Lock()
+		defer secondLock.Unlock()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("same-client report save lock was acquired while already held")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	lock.Unlock()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("same-client report save lock was not released")
+	}
+	lock.Lock()
+}
+
+func TestReportSaveLockAllowsDifferentClients(t *testing.T) {
+	firstLock := getReportSaveLock("client-lock-a")
+	firstLock.Lock()
+	defer firstLock.Unlock()
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(1)
+	acquired := make(chan struct{})
+	go func() {
+		defer waitGroup.Done()
+		secondLock := getReportSaveLock("client-lock-b")
+		secondLock.Lock()
+		defer secondLock.Unlock()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("different-client report save lock should not block")
+	}
+	waitGroup.Wait()
+}

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -88,6 +88,8 @@ type Record struct {
 	NetOut         int64     `json:"net_out" gorm:"type:bigint"`
 	NetTotalUp     int64     `json:"net_total_up" gorm:"type:bigint"`
 	NetTotalDown   int64     `json:"net_total_down" gorm:"type:bigint"`
+	TrafficUp      int64     `json:"traffic_up" gorm:"type:bigint"`
+	TrafficDown    int64     `json:"traffic_down" gorm:"type:bigint"`
 	Process        int       `json:"process"`
 	Connections    int       `json:"connections"`
 	ConnectionsUdp int       `json:"connections_udp"`

--- a/database/notification/traffic_report.go
+++ b/database/notification/traffic_report.go
@@ -1,10 +1,59 @@
 package notification
 
 import (
+	"fmt"
+
 	"github.com/komari-monitor/komari/database/dbcore"
 	"github.com/komari-monitor/komari/database/models"
 	"gorm.io/gorm/clause"
 )
+
+func validateTrafficReportNotification(notification models.TrafficReportNotification) error {
+	if notification.Client == "" {
+		return fmt.Errorf("client UUID cannot be empty")
+	}
+	if notification.Enable && !notification.Daily && !notification.Weekly && !notification.Monthly {
+		return fmt.Errorf("at least one cadence must be selected when enabling traffic reports")
+	}
+	return nil
+}
+
+func ValidateTrafficReportNotifications(notifications []models.TrafficReportNotification) error {
+	for _, notification := range notifications {
+		if err := validateTrafficReportNotification(notification); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildEnabledTrafficReportNotifications(uuids []string, existing []models.TrafficReportNotification) ([]models.TrafficReportNotification, error) {
+	if len(uuids) == 0 {
+		return nil, fmt.Errorf("at least one client UUID is required")
+	}
+
+	existingByClient := make(map[string]models.TrafficReportNotification, len(existing))
+	for _, notification := range existing {
+		existingByClient[notification.Client] = notification
+	}
+
+	notifications := make([]models.TrafficReportNotification, 0, len(uuids))
+	for _, uuid := range uuids {
+		if uuid == "" {
+			return nil, fmt.Errorf("client UUID cannot be empty")
+		}
+		existingNotification, ok := existingByClient[uuid]
+		if !ok || (!existingNotification.Daily && !existingNotification.Weekly && !existingNotification.Monthly) {
+			return nil, fmt.Errorf("at least one cadence must be selected when enabling traffic reports")
+		}
+		notifications = append(notifications, models.TrafficReportNotification{
+			Client: uuid,
+			Enable: true,
+		})
+	}
+
+	return notifications, nil
+}
 
 // ListTrafficReportNotifications 获取所有流量定时报告配置（关联客户端信息）
 func ListTrafficReportNotifications() ([]models.TrafficReportNotification, error) {
@@ -16,6 +65,9 @@ func ListTrafficReportNotifications() ([]models.TrafficReportNotification, error
 
 // EditTrafficReportNotifications 批量更新流量定时报告配置
 func EditTrafficReportNotifications(notifications []models.TrafficReportNotification) error {
+	if err := ValidateTrafficReportNotifications(notifications); err != nil {
+		return err
+	}
 	db := dbcore.GetDBInstance()
 	return db.Model(&models.TrafficReportNotification{}).
 		Clauses(clause.OnConflict{
@@ -28,13 +80,18 @@ func EditTrafficReportNotifications(notifications []models.TrafficReportNotifica
 
 // EnableTrafficReportNotifications 批量启用（仅更新 enable 字段）
 func EnableTrafficReportNotifications(uuids []string) error {
+	if len(uuids) == 0 {
+		return fmt.Errorf("at least one client UUID is required")
+	}
+
 	db := dbcore.GetDBInstance()
-	var notifications []models.TrafficReportNotification
-	for _, uuid := range uuids {
-		notifications = append(notifications, models.TrafficReportNotification{
-			Client: uuid,
-			Enable: true,
-		})
+	var existing []models.TrafficReportNotification
+	if err := db.Where("client IN ?", uuids).Find(&existing).Error; err != nil {
+		return err
+	}
+	notifications, err := buildEnabledTrafficReportNotifications(uuids, existing)
+	if err != nil {
+		return err
 	}
 	return db.Model(&models.TrafficReportNotification{}).
 		Clauses(clause.OnConflict{
@@ -47,9 +104,15 @@ func EnableTrafficReportNotifications(uuids []string) error {
 
 // DisableTrafficReportNotifications 批量禁用
 func DisableTrafficReportNotifications(uuids []string) error {
+	if len(uuids) == 0 {
+		return fmt.Errorf("at least one client UUID is required")
+	}
 	db := dbcore.GetDBInstance()
 	var notifications []models.TrafficReportNotification
 	for _, uuid := range uuids {
+		if uuid == "" {
+			return fmt.Errorf("client UUID cannot be empty")
+		}
 		notifications = append(notifications, models.TrafficReportNotification{
 			Client: uuid,
 			Enable: false,

--- a/database/notification/traffic_report_test.go
+++ b/database/notification/traffic_report_test.go
@@ -1,0 +1,36 @@
+package notification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/komari-monitor/komari/database/models"
+)
+
+func TestValidateTrafficReportNotificationsRejectsEnabledWithoutCadence(t *testing.T) {
+	err := ValidateTrafficReportNotifications([]models.TrafficReportNotification{{
+		Client: "client-a",
+		Enable: true,
+	}})
+
+	assert.Error(t, err)
+}
+
+func TestBuildEnabledTrafficReportNotificationsRequiresExistingCadence(t *testing.T) {
+	_, err := buildEnabledTrafficReportNotifications([]string{"client-a"}, nil)
+	assert.Error(t, err)
+
+	_, err = buildEnabledTrafficReportNotifications([]string{"client-a"}, []models.TrafficReportNotification{{Client: "client-a"}})
+	assert.Error(t, err)
+
+	notifications, err := buildEnabledTrafficReportNotifications([]string{"client-a"}, []models.TrafficReportNotification{{
+		Client: "client-a",
+		Daily:  true,
+	}})
+	require.NoError(t, err)
+	require.Len(t, notifications, 1)
+	assert.Equal(t, "client-a", notifications[0].Client)
+	assert.True(t, notifications[0].Enable)
+}

--- a/database/records/records.go
+++ b/database/records/records.go
@@ -180,12 +180,19 @@ func CompactRecord() error {
 }
 
 func migrateOldRecords(db *gorm.DB) error {
-	// 计算 4 小时前的时间
-	fourHoursAgo := time.Now().Add(-4 * time.Hour)
+	return migrateOldRecordsAt(db, time.Now())
+}
+
+func compactRecordCutoff(now time.Time) time.Time {
+	return now.Add(-4 * time.Hour).Truncate(15 * time.Minute)
+}
+
+func migrateOldRecordsAt(db *gorm.DB, now time.Time) error {
+	cutoff := compactRecordCutoff(now)
 
 	// 查询 records 表中超过 4 小时的记录
 	var records []models.Record
-	if err := db.Table("records").Where("time < ?", fourHoursAgo).Find(&records).Error; err != nil {
+	if err := db.Table("records").Where("time < ?", cutoff).Find(&records).Error; err != nil {
 		return err
 	}
 
@@ -195,24 +202,29 @@ func migrateOldRecords(db *gorm.DB) error {
 
 	// 按 Client 和 15 分钟时间段分组，并存储所有记录以计算分位数
 	type groupData struct {
-		Cpu            []float32
-		Gpu            []float32
-		Load           []float32
-		Temp           []float32
-		Ram            []int64
-		RamTotal       []int64
-		Swap           []int64
-		SwapTotal      []int64
-		Disk           []int64
-		DiskTotal      []int64
-		NetIn          []int64
-		NetOut         []int64
-		NetTotalUp     []int64
-		NetTotalDown   []int64
-		Process        []int
-		Connections    []int
-		ConnectionsUdp []int
-		Uptime         []int64
+		Cpu             []float32
+		Gpu             []float32
+		Load            []float32
+		Temp            []float32
+		Ram             []int64
+		RamTotal        []int64
+		Swap            []int64
+		SwapTotal       []int64
+		Disk            []int64
+		DiskTotal       []int64
+		NetIn           []int64
+		NetOut          []int64
+		NetTotalUp      []int64
+		NetTotalDown    []int64
+		TrafficUp       int64
+		TrafficDown     int64
+		LatestTime      time.Time
+		LatestTotalUp   int64
+		LatestTotalDown int64
+		Process         []int
+		Connections     []int
+		ConnectionsUdp  []int
+		Uptime          []int64
 	}
 
 	groupedRecords := make(map[string]*groupData)
@@ -236,6 +248,13 @@ func migrateOldRecords(db *gorm.DB) error {
 		data.NetOut = append(data.NetOut, record.NetOut)
 		data.NetTotalUp = append(data.NetTotalUp, record.NetTotalUp)
 		data.NetTotalDown = append(data.NetTotalDown, record.NetTotalDown)
+		data.TrafficUp += record.TrafficUp
+		data.TrafficDown += record.TrafficDown
+		if data.LatestTime.IsZero() || record.Time.ToTime().After(data.LatestTime) {
+			data.LatestTime = record.Time.ToTime()
+			data.LatestTotalUp = record.NetTotalUp
+			data.LatestTotalDown = record.NetTotalDown
+		}
 		data.Process = append(data.Process, record.Process)
 		data.Connections = append(data.Connections, record.Connections)
 		data.ConnectionsUdp = append(data.ConnectionsUdp, record.ConnectionsUdp)
@@ -329,8 +348,10 @@ func migrateOldRecords(db *gorm.DB) error {
 				DiskTotal:      getIntPercentile(data.DiskTotal, high_percentile),
 				NetIn:          getIntPercentile(data.NetIn, 0.2),
 				NetOut:         getIntPercentile(data.NetOut, 0.2),
-				NetTotalUp:     getIntPercentile(data.NetTotalUp, high_percentile),
-				NetTotalDown:   getIntPercentile(data.NetTotalDown, high_percentile),
+				NetTotalUp:     data.LatestTotalUp,
+				NetTotalDown:   data.LatestTotalDown,
+				TrafficUp:      data.TrafficUp,
+				TrafficDown:    data.TrafficDown,
 				Process:        getInt32Percentile(data.Process, high_percentile),
 				Connections:    getInt32Percentile(data.Connections, high_percentile),
 				ConnectionsUdp: getInt32Percentile(data.ConnectionsUdp, high_percentile),
@@ -350,7 +371,7 @@ func migrateOldRecords(db *gorm.DB) error {
 		}
 
 		// 删除 records 表中的旧数据
-		if err := tx.Table("records").Where("time < ?", fourHoursAgo.Add(-1*time.Hour)).Delete(&models.Record{}).Error; err != nil {
+		if err := tx.Table("records").Where("time < ?", cutoff.Add(-1*time.Hour)).Delete(&models.Record{}).Error; err != nil {
 			return err
 		}
 
@@ -360,11 +381,11 @@ func migrateOldRecords(db *gorm.DB) error {
 
 // migrateGPURecords 压缩GPU记录数据
 func migrateGPURecords(db *gorm.DB) error {
-	fourHoursAgo := time.Now().Add(-4 * time.Hour)
+	cutoff := compactRecordCutoff(time.Now())
 
 	// 查询超过4小时的GPU记录
 	var gpuRecords []models.GPURecord
-	if err := db.Where("time < ?", fourHoursAgo).Find(&gpuRecords).Error; err != nil {
+	if err := db.Where("time < ?", cutoff).Find(&gpuRecords).Error; err != nil {
 		return err
 	}
 
@@ -494,7 +515,7 @@ func migrateGPURecords(db *gorm.DB) error {
 		}
 
 		// 删除已压缩的原始GPU数据
-		if err := tx.Where("time < ?", fourHoursAgo.Add(-1*time.Hour)).Delete(&models.GPURecord{}).Error; err != nil {
+		if err := tx.Where("time < ?", cutoff.Add(-1*time.Hour)).Delete(&models.GPURecord{}).Error; err != nil {
 			return err
 		}
 

--- a/database/records/records_test.go
+++ b/database/records/records_test.go
@@ -25,8 +25,9 @@ var _ = func() bool {
 // then running migrateOldRecords and verifying the aggregation and cleanup.
 func TestCompactRecord(t *testing.T) {
 	const totalMinutes = 12*60 + 30
-	now := time.Now()
-	threshold := now.Add(-4 * time.Hour)
+	now := time.Now().UTC().Truncate(time.Minute)
+	threshold := compactRecordCutoff(now)
+	overlapCutoff := threshold.Add(-1 * time.Hour)
 
 	// 使用 sqlite 内存数据库并迁移表结构
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -35,7 +36,7 @@ func TestCompactRecord(t *testing.T) {
 	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
 
 	expectedGroups := make(map[time.Time]struct{})
-	expectedRemain := 0
+	expectedRawRemain := 0
 
 	// 插入数据
 	for i := 0; i < totalMinutes; i++ {
@@ -45,10 +46,11 @@ func TestCompactRecord(t *testing.T) {
 		assert.NoError(t, err)
 
 		if recTime.Before(threshold) {
-			slot := recTime.Truncate(time.Hour)
+			slot := recTime.Truncate(15 * time.Minute)
 			expectedGroups[slot] = struct{}{}
-		} else {
-			expectedRemain++
+		}
+		if !recTime.Before(overlapCutoff) {
+			expectedRawRemain++
 		}
 	}
 
@@ -75,7 +77,7 @@ func TestCompactRecord(t *testing.T) {
 	}
 
 	// 运行压缩（迁移）逻辑
-	err = migrateOldRecords(db)
+	err = migrateOldRecordsAt(db, now)
 	assert.NoError(t, err)
 
 	// 验证 long-term 表中的聚合记录数
@@ -86,7 +88,7 @@ func TestCompactRecord(t *testing.T) {
 	// 验证原始表中剩余记录数
 	var remainCount int64
 	assert.NoError(t, db.Table("records").Count(&remainCount).Error)
-	assert.Equal(t, int64(expectedRemain), remainCount+1)
+	assert.Equal(t, int64(expectedRawRemain), remainCount)
 
 	// 导出压缩后的数据到 CSV
 	var compRecs []models.Record
@@ -127,4 +129,106 @@ func TestCompactRecord(t *testing.T) {
 			strconv.FormatInt(r.Ram, 10),
 		})
 	}
+}
+
+func TestCompactRecordPreservesExactTrafficDelta(t *testing.T) {
+	currentTime := time.Now().UTC().Truncate(time.Minute)
+	now := currentTime.Truncate(15 * time.Minute).Add(-5*time.Hour + time.Minute)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	records := []models.Record{
+		{
+			Client:       uuid,
+			Time:         models.FromTime(now),
+			NetTotalUp:   100,
+			NetTotalDown: 200,
+			TrafficUp:    0,
+			TrafficDown:  0,
+		},
+		{
+			Client:       uuid,
+			Time:         models.FromTime(now.Add(5 * time.Minute)),
+			NetTotalUp:   150,
+			NetTotalDown: 260,
+			TrafficUp:    50,
+			TrafficDown:  60,
+		},
+		{
+			Client:       uuid,
+			Time:         models.FromTime(now.Add(10 * time.Minute)),
+			NetTotalUp:   10,
+			NetTotalDown: 30,
+			TrafficUp:    10,
+			TrafficDown:  30,
+		},
+	}
+
+	for _, rec := range records {
+		assert.NoError(t, db.Create(&rec).Error)
+	}
+
+	assert.NoError(t, migrateOldRecordsAt(db, currentTime))
+
+	var compacted []models.Record
+	assert.NoError(t, db.Table("records_long_term").Find(&compacted).Error)
+	assert.Len(t, compacted, 1)
+	assert.Equal(t, int64(60), compacted[0].TrafficUp)
+	assert.Equal(t, int64(90), compacted[0].TrafficDown)
+	assert.Equal(t, int64(10), compacted[0].NetTotalUp)
+	assert.Equal(t, int64(30), compacted[0].NetTotalDown)
+	assert.True(t, compacted[0].Time.ToTime().Equal(records[2].Time.ToTime().Truncate(15*time.Minute)))
+}
+
+func TestCompactRecordRetainsOneHourOverlapWindow(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 7, 0, 0, time.UTC)
+	cutoff := compactRecordCutoff(now)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	records := []models.Record{
+		{Client: uuid, Time: models.FromTime(cutoff.Add(-time.Hour - time.Minute)), TrafficUp: 5},
+		{Client: uuid, Time: models.FromTime(cutoff.Add(-30 * time.Minute)), TrafficUp: 7},
+		{Client: uuid, Time: models.FromTime(now.Add(-3 * time.Hour)), TrafficUp: 11},
+	}
+	for _, rec := range records {
+		assert.NoError(t, db.Create(&rec).Error)
+	}
+
+	assert.NoError(t, migrateOldRecordsAt(db, now))
+
+	var remainTimes []models.Record
+	assert.NoError(t, db.Table("records").Order("time ASC").Find(&remainTimes).Error)
+	assert.Len(t, remainTimes, 2)
+	assert.True(t, remainTimes[0].Time.ToTime().Equal(records[1].Time.ToTime()))
+	assert.True(t, remainTimes[1].Time.ToTime().Equal(records[2].Time.ToTime()))
+}
+
+func TestCompactRecordOnlyMigratesCompleteFifteenMinuteBuckets(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 7, 0, 0, time.UTC)
+	cutoff := compactRecordCutoff(now)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	compactable := models.Record{Client: uuid, Time: models.FromTime(cutoff.Add(-time.Minute)), TrafficUp: 5}
+	partialSlot := models.Record{Client: uuid, Time: models.FromTime(cutoff.Add(time.Minute)), TrafficUp: 7}
+	assert.NoError(t, db.Create(&compactable).Error)
+	assert.NoError(t, db.Create(&partialSlot).Error)
+
+	assert.NoError(t, migrateOldRecordsAt(db, now))
+
+	var compacted []models.Record
+	assert.NoError(t, db.Table("records_long_term").Order("time ASC").Find(&compacted).Error)
+	assert.Len(t, compacted, 1)
+	assert.True(t, compacted[0].Time.ToTime().Equal(compactable.Time.ToTime().Truncate(15*time.Minute)))
+
+	var rawCount int64
+	assert.NoError(t, db.Table("records").Where("time = ?", partialSlot.Time).Count(&rawCount).Error)
+	assert.Equal(t, int64(1), rawCount)
 }

--- a/utils/notifier/traffic_report.go
+++ b/utils/notifier/traffic_report.go
@@ -12,6 +12,7 @@ import (
 	"github.com/komari-monitor/komari/pkg/config"
 	"github.com/komari-monitor/komari/pkg/corn"
 	"github.com/komari-monitor/komari/utils/messageSender"
+	"gorm.io/gorm"
 )
 
 // InitTrafficReportSchedule 注册三个定时任务：日报、周报、月报
@@ -123,6 +124,7 @@ func sendTrafficReport(daily, weekly, monthly bool) {
 
 	// 为每个服务器统计流量并拼接消息
 	var lines []string
+	eventClients := make([]models.Client, 0, len(notifications))
 	for _, n := range notifications {
 		c, ok := clientMap[n.Client]
 		if !ok {
@@ -136,6 +138,7 @@ func sendTrafficReport(daily, weekly, monthly bool) {
 		}
 
 		lines = append(lines, fmt.Sprintf("%s%s：%s", c.Name, suffix, humanBytes(used)))
+		eventClients = append(eventClients, c)
 	}
 
 	if len(lines) == 0 {
@@ -155,6 +158,7 @@ func sendTrafficReport(daily, weekly, monthly bool) {
 
 	if err := messageSender.SendEvent(models.EventMessage{
 		Event:   eventType,
+		Clients: eventClients,
 		Time:    now,
 		Emoji:   emoji,
 		Message: message,
@@ -164,44 +168,54 @@ func sendTrafficReport(daily, weekly, monthly bool) {
 }
 
 // getClientTrafficInRange 查询某客户端在指定时间段内的流量增量
-// 通过取时间段内 NetTotalUp/NetTotalDown 的 max - min 计算增量
+// 通过累加持久化的精确流量增量字段计算用量
 func getClientTrafficInRange(clientUUID string, trafficType string, start, end time.Time) (int64, error) {
-	db := dbcore.GetDBInstance()
+	return getClientTrafficInRangeWithDB(dbcore.GetDBInstance(), clientUUID, trafficType, start, end)
+}
 
-	type minMax struct {
-		MinUp   int64 `gorm:"column:min_up"`
-		MaxUp   int64 `gorm:"column:max_up"`
-		MinDown int64 `gorm:"column:min_down"`
-		MaxDown int64 `gorm:"column:max_down"`
+func getClientTrafficInRangeWithDB(db *gorm.DB, clientUUID string, trafficType string, start, end time.Time) (int64, error) {
+	type trafficDeltaRecord struct {
+		Time        models.LocalTime `gorm:"column:time"`
+		TrafficUp   int64            `gorm:"column:traffic_up"`
+		TrafficDown int64            `gorm:"column:traffic_down"`
 	}
-	var result minMax
 
-	sql := `
-		SELECT
-			MIN(net_total_up)   AS min_up,
-			MAX(net_total_up)   AS max_up,
-			MIN(net_total_down) AS min_down,
-			MAX(net_total_down) AS max_down
-		FROM (
-			SELECT net_total_up, net_total_down FROM records
-			WHERE client = ? AND time >= ? AND time <= ?
-			UNION ALL
-			SELECT net_total_up, net_total_down FROM records_long_term
-			WHERE client = ? AND time >= ? AND time <= ?
-		) AS combined
-	`
-	if err := db.Raw(sql, clientUUID, start, end, clientUUID, start, end).Scan(&result).Error; err != nil {
+	var recentRecords []trafficDeltaRecord
+	if err := db.Table("records").
+		Select("time, traffic_up, traffic_down").
+		Where("client = ? AND time >= ? AND time <= ?", clientUUID, start, end).
+		Find(&recentRecords).Error; err != nil {
 		return 0, err
 	}
 
-	deltaUp := result.MaxUp - result.MinUp
-	if deltaUp < 0 {
-		deltaUp = result.MaxUp
-	}
-	deltaDown := result.MaxDown - result.MinDown
-	if deltaDown < 0 {
-		deltaDown = result.MaxDown
+	var longTermRecords []trafficDeltaRecord
+	if err := db.Table("records_long_term").
+		Select("time, traffic_up, traffic_down").
+		Where("client = ? AND time >= ? AND time <= ?", clientUUID, start, end).
+		Find(&longTermRecords).Error; err != nil {
+		return 0, err
 	}
 
-	return computeUsedByType(strings.ToLower(trafficType), deltaUp, deltaDown), nil
+	var totalUp int64
+	var totalDown int64
+	longTermSlots := make(map[time.Time]struct{}, len(longTermRecords))
+
+	for _, record := range longTermRecords {
+		totalUp += record.TrafficUp
+		totalDown += record.TrafficDown
+		longTermSlots[record.Time.ToTime()] = struct{}{}
+	}
+
+	for _, record := range recentRecords {
+		// records_long_term stores one aggregated row per 15-minute slot.
+		// Skip raw rows only when that exact slot is already present there.
+		slot := record.Time.ToTime().Truncate(15 * time.Minute)
+		if _, exists := longTermSlots[slot]; exists {
+			continue
+		}
+		totalUp += record.TrafficUp
+		totalDown += record.TrafficDown
+	}
+
+	return computeUsedByType(strings.ToLower(trafficType), totalUp, totalDown), nil
 }

--- a/utils/notifier/traffic_report_test.go
+++ b/utils/notifier/traffic_report_test.go
@@ -1,0 +1,65 @@
+package notifier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/komari-monitor/komari/database/models"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetClientTrafficInRangeAvoidsOverlappingRawAndLongTermRows(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	clientUUID := "client-overlap"
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	sharedSlot := start.Add(15 * time.Minute)
+
+	assert.NoError(t, db.Table("records_long_term").Create(&models.Record{
+		Client:      clientUUID,
+		Time:        models.FromTime(sharedSlot),
+		TrafficUp:   100,
+		TrafficDown: 200,
+	}).Error)
+
+	rawRecords := []models.Record{
+		{Client: clientUUID, Time: models.FromTime(sharedSlot.Add(1 * time.Minute)), TrafficUp: 40, TrafficDown: 80},
+		{Client: clientUUID, Time: models.FromTime(sharedSlot.Add(5 * time.Minute)), TrafficUp: 60, TrafficDown: 120},
+		{Client: clientUUID, Time: models.FromTime(sharedSlot.Add(16 * time.Minute)), TrafficUp: 30, TrafficDown: 50},
+	}
+	for _, record := range rawRecords {
+		assert.NoError(t, db.Create(&record).Error)
+	}
+
+	used, err := getClientTrafficInRangeWithDB(db, clientUUID, "sum", start, sharedSlot.Add(30*time.Minute))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(380), used)
+}
+
+func TestGetClientTrafficInRangeSumsPersistedDeltasAcrossCounterReset(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	clientUUID := "client-reset"
+	start := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	records := []models.Record{
+		{Client: clientUUID, Time: models.FromTime(start.Add(0 * time.Minute)), NetTotalUp: 100, NetTotalDown: 200, TrafficUp: 0, TrafficDown: 0},
+		{Client: clientUUID, Time: models.FromTime(start.Add(5 * time.Minute)), NetTotalUp: 150, NetTotalDown: 260, TrafficUp: 50, TrafficDown: 60},
+		{Client: clientUUID, Time: models.FromTime(start.Add(10 * time.Minute)), NetTotalUp: 10, NetTotalDown: 30, TrafficUp: 10, TrafficDown: 30},
+		{Client: clientUUID, Time: models.FromTime(start.Add(15 * time.Minute)), NetTotalUp: 25, NetTotalDown: 40, TrafficUp: 15, TrafficDown: 10},
+	}
+	for _, record := range records {
+		assert.NoError(t, db.Create(&record).Error)
+	}
+
+	used, err := getClientTrafficInRangeWithDB(db, clientUUID, "sum", start, start.Add(20*time.Minute))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(175), used)
+}

--- a/web/api/admin/notification/traffic_report.go
+++ b/web/api/admin/notification/traffic_report.go
@@ -29,11 +29,9 @@ func EditTrafficReportNotifications(c *gin.Context) {
 		api.RespondError(c, 400, "At least one notification is required")
 		return
 	}
-	for _, n := range notifications {
-		if n.Client == "" {
-			api.RespondError(c, 400, "Client UUID cannot be empty")
-			return
-		}
+	if err := notification.ValidateTrafficReportNotifications(notifications); err != nil {
+		api.RespondError(c, 400, err.Error())
+		return
 	}
 	if err := notification.EditTrafficReportNotifications(notifications); err != nil {
 		api.RespondError(c, 500, "Failed to edit traffic report notifications: "+err.Error())


### PR DESCRIPTION
## 变更概述

本次修复主要针对此前引入“流量定时报告”功能后发现的一组后续问题，覆盖后端统计逻辑、压缩数据边界、并发写入、配置状态约束、前端保存交互，以及后台菜单展示问题。

核心目标包括：

1. 修复定时流量报告的统计不准确问题
2. 修复长期压缩数据与原始数据混合读取时可能漏算的问题
3. 修复并发上报时流量增量可能重复计算的问题
4. 修复前端保存失败却提示成功的问题
5. 修复“启用但未选择任何日报/周报/月报”的无效配置状态
6. 修复后台菜单中“流量定时报告”页面图标缺失，以及报告类型展示分隔符未做 i18n 的问题

---

## 之前提交存在的问题

### 1. 定时流量报告统计值存在结构性误差

此前实现是在发送日报/周报/月报时，直接从 `records` 和 `records_long_term` 中读取 `net_total_up` / `net_total_down`，再通过 `max - min` 反推一段时间内的流量增量。

这种做法有两个根本问题：

#### 1.1 长期表不是原始精确快照

`records_long_term` 中的数据不是原始逐条上报记录，而是经过 15 分钟粒度压缩聚合后的结果。它不能再被当作统计周期起点/终点的真实累计计数器快照使用。

因此，一旦日报/周报/月报统计区间跨入长期表，仅靠累计计数器的 `max - min` 无法保证得到真实流量。

#### 1.2 节点重启或计数器归零时会严重误报

如果节点在统计周期内重启，累计流量计数器可能回绕或归零。此前逻辑仍使用整段区间的 `max - min`，会错误组合重启前后的计数器值，导致周期流量明显失真。

---

### 2. 长期压缩桶可能是不完整的

后续修复把报表读取改为求和 `traffic_up` / `traffic_down` 后，还需要避免长期表和原始表混合读取时重复计算。

此前读取逻辑会在发现某个 15 分钟长期桶存在时，跳过同一桶内的原始记录。但压缩任务是按运行时刻计算“4 小时前”的滚动时间点，不保证刚好落在 15 分钟边界。

这会导致：

- 某个长期 15 分钟桶只包含该桶前半段数据
- 同一桶后半段原始记录仍保留在 `records`
- 报表读取时因为长期桶已存在而跳过这些原始记录
- 最终日报/周报/月报短时间内漏算流量

---

### 3. 并发上报可能导致增量重复计算

新增 `traffic_up` / `traffic_down` 后，每条记录的增量依赖“当前累计值”和“上一条记录累计值”的差值。

如果同一个客户端的两次上报并发进入保存流程，两个事务可能同时读取到同一条上一记录，并分别计算增量，导致实际只增长一次的流量被重复计入。

---

### 4. 前端保存流程在接口失败时仍然提示成功

此前流量定时报告页面在单条编辑和批量编辑两个入口中，都存在同样的问题：

- `fetch` 返回非 2xx 时，先弹出错误提示
- 但后续逻辑仍继续执行成功分支
- 用户会看到“保存失败”和“更新成功”混杂出现
- 弹窗会被关闭，页面会刷新，容易误导后台操作人员

---

### 5. 配置层允许出现无效启用状态

此前系统允许保存：

- `enable = true`
- `daily = false`
- `weekly = false`
- `monthly = false`

这种状态在表格里看起来像“已启用”，但调度逻辑不会命中任何报告类型，属于无意义配置。

后续检查还发现，虽然编辑接口已经增加了校验，但旧的 enable 接口仍可绕过该约束，直接创建或恢复这种非法状态。

---

### 6. 菜单图标缺失与展示文案未本地化

菜单配置中已经为“流量定时报告”指定了 `BarChart2`，但图标映射表里没有注册该图标，导致后台菜单无法正确显示图标。

同时，页面中“日报 / 周报 / 月报”的组合展示此前使用固定分隔符，未做 i18n。

---

## 本次修复方案

### 一、重构流量统计模型：写入时计算精确增量，读取时直接求和

本次不再在报表发送时通过累计计数器反推区间流量，而是改为：

1. 在 `Record` 模型中新增 `traffic_up` / `traffic_down`
2. 客户端上报时读取上一条记录并计算本次真实增量
3. 若累计计数器正常递增，则使用差值
4. 若计数器回绕或归零，则把当前累计值视作重启后的新增流量
5. 报表统计时直接求和 `traffic_up` / `traffic_down`

这样可以从根本上修复长期压缩数据无法反推精确流量、以及节点重启导致误报的问题。

---

### 二、长期压缩只处理完整的 15 分钟桶

压缩 cutoff 现在会先计算“4 小时前”，再向下对齐到 15 分钟边界。

也就是说，压缩只会迁移已经完整落在 cutoff 之前的 15 分钟桶，不再把一个尚未完整过期的桶提前写入 `records_long_term`。

这样可以保证：

- 长期表中的 15 分钟桶代表完整时间桶
- 报表读取时跳过同桶原始记录不会漏算
- 原始表与长期表的重叠窗口仍然保留，但不会产生部分桶可见性问题

---

### 三、长期表压缩保留精确增量总和

在 `records -> records_long_term` 聚合迁移中：

- `traffic_up` / `traffic_down` 按时间桶累加
- `net_total_up` / `net_total_down` 保留该桶最后一条记录的累计值

这样长期表仍可用于后续周期报表，并且周期流量可以直接通过求和得到。

---

### 四、同一客户端上报保存增加 per-client 锁

为避免并发上报重复读取同一条上一记录，本次在保存客户端报告时增加按 client UUID 分组的互斥锁。

效果是：

- 同一客户端的上报保存串行执行
- 不同客户端之间仍可并发保存
- `traffic_up` / `traffic_down` 的计算拥有稳定的上一记录顺序
- 避免并发情况下流量被重复计入

---

### 五、统一后端配置合法性校验

本次将“启用时必须选择至少一种报告周期”的规则下沉到数据库通知配置层，而不是只放在 HTTP edit handler 中。

现在以下路径都会受到同一规则保护：

- 批量编辑配置
- 旧的启用接口
- 直接调用数据库通知配置方法

旧的 enable 接口不再允许为无 cadence 的配置设置 `enable = true`。如果客户端尚未配置日报/周报/月报，或已有配置中三者全为 false，则启用会被拒绝。

---

### 六、修复前端保存错误处理逻辑

对流量定时报告页面中单条编辑和批量编辑两个保存入口做了统一修复：

- 非 2xx 响应读取后端返回 JSON 并抛出错误
- 成功提示只在真正成功时展示
- 弹窗只在真正成功时关闭
- 失败时保留当前弹窗和编辑状态
- 将后端错误消息直接反馈给用户

---

### 七、修复菜单图标问题并补齐 i18n

已将 `BarChart2` 注册到图标映射表中，后台菜单可以正确显示“流量定时报告”入口图标。

报告类型组合展示中的分隔符改为通过 i18n 配置提供：

- 英文 / 印尼语使用 `, `
- 中文 / 日文使用 `、`

---

## 额外处理

### 同步更新嵌入式前端静态资源

由于 `komari` 后端二进制会嵌入 `web/public/defaultTheme/dist` 中的前端构建产物，因此在修复 `komari-web` 源码后，也需要重新构建并同步拷贝静态资源到 `komari` 对应目录。

否则即使前端源码已修复，最终构建出的 `komari` 二进制仍可能携带旧页面资源。

---

## 验证情况

### 后端

已执行并通过：

- `go test -count=1 ./database/records ./database/clients ./database/notification ./utils/notifier ./web/api/admin/notification`

同时确认本次涉及文件无新增诊断错误。

补充说明：

- 曾执行 `go test ./...`
- 当前仍有既有的非本次改动相关失败，集中在 `web/api/public` 登录响应测试和 `web/oauth` provider config 测试
- 本次修改涉及的流量报告相关包均已通过测试

### 前端

已执行并通过：

- `npm run build`

---

## 影响范围

本次改动影响以下方面：

- 流量定时报告的周期统计结果
- 原始记录到长期记录的压缩边界
- 同一客户端并发上报时的流量增量计算
- 后台流量定时报告配置页保存交互
- 后端流量报告配置状态合法性
- 后台菜单中流量定时报告入口图标显示
- 多语言下报告类型组合的展示形式
- `komari` 二进制打包时嵌入的默认主题静态资源

---

## 兼容性说明

当前新逻辑依赖新增的 `traffic_up` / `traffic_down` 字段。

对于历史旧数据：

- 新字段在旧记录中默认可能为空或为 0
- 修复部署后，新产生的记录会按正确方式保存精确增量
- 周期报表从部署后开始会逐步变得准确
- 本次未引入历史回填逻辑，以避免扩大修复范围
- 若需要对历史记录进行修正，后续可以单独设计 backfill 方案