### PR TITLE
fix(remote-exec): preserve command text during validation

### DIFF
--- a/web/api/admin/exec.go
+++ b/web/api/admin/exec.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -29,6 +30,10 @@ func Exec(c *gin.Context) {
 	var offlineClients []string
 	if err := c.ShouldBindJSON(&req); err != nil {
 		api.RespondError(c, 400, "Invalid or missing request body: "+err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Command) == "" {
+		api.RespondError(c, 400, "Command cannot be empty")
 		return
 	}
 	// for uuid := range ws.GetConnectedClients() {


### PR DESCRIPTION
Reject whitespace-only remote exec commands without trimming the submitted command body, so multiline scripts and meaningful leading/trailing content are preserved through dispatch.