### PR TITLE
test(auth): 清理已废弃的开发环境 Cookie 绕过逻辑

### DIFF
--- a/web/api/public/login_test.go
+++ b/web/api/public/login_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/komari-monitor/komari/database/accounts"
-	"github.com/komari-monitor/komari/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -104,36 +103,38 @@ func TestLogin(t *testing.T) {
 	accounts.DeleteAllSessions()
 }
 
-func TestSessionCookieIsSecureOnHTTPByDefault(t *testing.T) {
+func TestSessionCookieSecureFollowsRequestScheme(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	original := utils.CurrentVersion
-	utils.CurrentVersion = "0.0.1"
-	defer func() {
-		utils.CurrentVersion = original
-	}()
+	tests := []struct {
+		name       string
+		requestURL string
+		wantSecure bool
+	}{
+		{
+			name:       "http",
+			requestURL: "http://example.test/login",
+		},
+		{
+			name:       "https",
+			requestURL: "https://example.test/login",
+			wantSecure: true,
+		},
+	}
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "http://example.test/login", nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, tt.requestURL, nil)
 
-	setSessionCookie(c, "test-session", sessionCookieMaxAge)
+			setSessionCookie(c, "test-session", sessionCookieMaxAge)
 
-	assert.Contains(t, strings.Join(w.Header().Values("Set-Cookie"), "\n"), "Secure")
-}
-
-func TestSessionCookieIsNotSecureOnHTTPWhenOverrideEnabled(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	original := utils.CurrentVersion
-	utils.CurrentVersion = "dev"
-	defer func() {
-		utils.CurrentVersion = original
-	}()
-
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "http://example.test/login", nil)
-
-	setSessionCookie(c, "test-session", sessionCookieMaxAge)
-
-	assert.NotContains(t, strings.Join(w.Header().Values("Set-Cookie"), "\n"), "Secure")
+			setCookie := strings.Join(w.Header().Values("Set-Cookie"), "\n")
+			if tt.wantSecure {
+				assert.Contains(t, setCookie, "Secure")
+			} else {
+				assert.NotContains(t, setCookie, "Secure")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## 变更内容

- 根据 https://github.com/komari-monitor/komari/commit/f7fd459723577610d3bf46aaa680ba27efcfba63 移除登录测试中对 `utils.CurrentVersion == "dev"` 的 Cookie 安全属性绕过验证
- 将会话 Cookie 测试调整为直接根据请求协议验证行为：
  - HTTP 请求不设置 `Secure`
  - HTTPS 请求设置 `Secure`

## 背景

此前为支持本地开发环境下的 HTTP 登录，曾通过开发版本判断允许非安全 Cookie。由于当前逻辑已调整为按请求协议决定是否设置 `Secure`，该开发环境绕过逻辑已不再需要，相关测试也应同步清理。