### PR TITLE
fix(router): 修复 RPC2 迁移引入的接口契约回归

### DIFF
--- a/web/router/router.go
+++ b/web/router/router.go
@@ -37,10 +37,12 @@ func registerPublicRoutes(r *gin.Engine) {
 	r.GET("/api/oauth", public_api.OAuth)
 	r.GET("/api/oauth_callback", public_api.OAuthCallback)
 	r.GET("/api/mjpeg_live", public_api.MjpegLiveHandler)
+	// /api/clients 是 WebSocket 端点（客户端发 "get"/"get <uuid>" 拉取在线列表与最新上报），
+	// 非 JSON-RPC，保留为 WS handler。
+	r.GET("/api/clients", api.GetClients)
 
 	// JSON 接口 -> RPC2。
 	r.GET("/api/me", jsonRpc.Bind("public:getMe", jsonRpc.WithRaw()))
-	r.GET("/api/clients", jsonRpc.Bind("public:getNodesInformation"))
 	r.GET("/api/nodes", jsonRpc.Bind("public:getNodesInformation"))
 	r.GET("/api/public", jsonRpc.Bind("public:getPublicSettings"))
 	r.GET("/api/version", jsonRpc.Bind("public:getVersion"))
@@ -137,9 +139,9 @@ func registerAdminRoutes(r *gin.Engine) {
 		settings.POST("/", jsonRpc.Bind("admin:editSettings"))
 		settings.GET("/xtermjs", jsonRpc.Bind("admin:getXtermjsSettings"))
 		settings.POST("/xtermjs", jsonRpc.Bind("admin:setXtermjsSettings", jsonRpc.WithMessage("settings saved")))
-		settings.POST("/oidc", jsonRpc.Bind("admin:setOidcProvider", jsonRpc.WithFlat()))
+		settings.POST("/oidc", jsonRpc.Bind("admin:setOidcProvider"))
 		settings.GET("/oidc", jsonRpc.Bind("admin:getOidcProvider", jsonRpc.WithQuery("provider")))
-		settings.POST("/message-sender", jsonRpc.Bind("admin:setMessageSenderProvider", jsonRpc.WithFlat()))
+		settings.POST("/message-sender", jsonRpc.Bind("admin:setMessageSenderProvider"))
 		settings.GET("/message-sender", jsonRpc.Bind("admin:getMessageSenderProvider", jsonRpc.WithQuery("provider")))
 		settings.GET("/cloudflared", jsonRpc.Bind("admin:getCloudflaredStatus"))
 		settings.POST("/cloudflared/start", jsonRpc.Bind("admin:startCloudflared"))


### PR DESCRIPTION
## 背景

#550（RPC2 统一管道全量迁移）在把 REST 接口迁移到声明式路由桥时，引入了 3 处对外契约破坏。本 PR 对照 `1.1.7` 与重构前基线逐路由核对后修复。

## 修复

### 1. `/api/clients` 误把 WebSocket 端点改成了 REST（核心 bug）
`GET /api/clients` 实际是 WebSocket 端点（`api.GetClients`：客户端发送 `get` / `get <uuid>` 拉取在线列表与最新上报）。迁移时被误绑为 `jsonRpc.Bind("public:getNodesInformation")`（普通 REST），导致前端 `wss://.../api/clients` 连接失败。

已还原为 `api.GetClients`。

### 2 & 3. provider 配置接口响应形状错位
`POST /api/admin/settings/oidc` 与 `POST /api/admin/settings/message-sender` 原响应为：
```json
{"status":"success","message":"","data":{"message":"... set successfully"}}
```
误用 `WithFlat()` 后变成 `{"status":"success","message":"..."}`，丢失了 `data` 层。移除 `WithFlat()`，RPC 方法返回的 `{message:...}` 经默认渲染器回到 `data.message`，恢复原契约。

## 验证

- 与 `1.1.7` 全量路由比对：对外路径集、方法、WebSocket/流端点、响应渲染器均一致；差异仅为 `1.1.7` 之后新增的功能（cloudflared / xtermjs / v2 rpc / ping 等）。
- 关键确认：`/api/clients` 在 `1.1.7` 与重构前均为 WebSocket，修复方向正确。
- `go build ./...`、`go vet ./...`、`go test ./web/... ./pkg/rpc/...` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)