### PR TITLE
fix: 修复流量报告为 0 B 问题

### DIFF
--- a/database/clients/report.go
+++ b/database/clients/report.go
@@ -11,6 +11,7 @@ import (
 	"github.com/komari-monitor/komari/database/dbcore"
 	"github.com/komari-monitor/komari/database/models"
 	v1 "github.com/komari-monitor/komari/protocol/v1"
+	"github.com/komari-monitor/komari/utils"
 
 	"gorm.io/gorm"
 )
@@ -20,17 +21,6 @@ var reportSaveLocks sync.Map
 func getReportSaveLock(clientUUID string) *sync.Mutex {
 	lock, _ := reportSaveLocks.LoadOrStore(clientUUID, &sync.Mutex{})
 	return lock.(*sync.Mutex)
-}
-
-func computeTrafficDelta(current, previous int64) int64 {
-	if previous < 0 {
-		return 0
-	}
-	if current >= previous {
-		return current - previous
-	}
-	// Counter reset or reboot: treat the new counter value as traffic since reset.
-	return current
 }
 
 func getLatestTrafficRecord(tx *gorm.DB, clientUUID string) (*models.Record, error) {
@@ -246,8 +236,8 @@ func SaveClientReport(clientUUID string, report v1.Report) (err error) {
 			return fmt.Errorf("failed to load previous Record: %w", err)
 		}
 		if previous != nil {
-			Record.TrafficUp = computeTrafficDelta(report.Network.TotalUp, previous.NetTotalUp)
-			Record.TrafficDown = computeTrafficDelta(report.Network.TotalDown, previous.NetTotalDown)
+			Record.TrafficUp = utils.ComputeTrafficDelta(report.Network.TotalUp, previous.NetTotalUp)
+			Record.TrafficDown = utils.ComputeTrafficDelta(report.Network.TotalDown, previous.NetTotalDown)
 		}
 
 		// 保存 Record

--- a/database/clients/report_test.go
+++ b/database/clients/report_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/komari-monitor/komari/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +24,7 @@ func TestComputeTrafficDeltaHandlesZeroAndReset(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.want, computeTrafficDelta(test.current, test.previous))
+			assert.Equal(t, test.want, utils.ComputeTrafficDelta(test.current, test.previous))
 		})
 	}
 }

--- a/database/records/records.go
+++ b/database/records/records.go
@@ -1,6 +1,7 @@
 package records
 
 import (
+	"errors"
 	"log"
 	"sort"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/komari-monitor/komari/cmd/flags"
 	"github.com/komari-monitor/komari/database/dbcore"
 	"github.com/komari-monitor/komari/database/models"
+	"github.com/komari-monitor/komari/utils"
 )
 
 func RecordOne(rec models.Record) error {
@@ -199,6 +201,11 @@ func migrateOldRecordsAt(db *gorm.DB, now time.Time) error {
 	if len(records) == 0 {
 		return nil
 	}
+	previousByClient, err := getPreviousTrafficRecordsBefore(db, records)
+	if err != nil {
+		return err
+	}
+	repairZeroTrafficDeltas(records, previousByClient)
 
 	// 按 Client 和 15 分钟时间段分组，并存储所有记录以计算分位数
 	type groupData struct {
@@ -377,6 +384,84 @@ func migrateOldRecordsAt(db *gorm.DB, now time.Time) error {
 
 		return nil
 	})
+}
+
+func getPreviousTrafficRecordsBefore(db *gorm.DB, records []models.Record) (map[string]*models.Record, error) {
+	firstTimeByClient := make(map[string]time.Time)
+	for _, record := range records {
+		recordTime := record.Time.ToTime()
+		firstTime, ok := firstTimeByClient[record.Client]
+		if !ok || recordTime.Before(firstTime) {
+			firstTimeByClient[record.Client] = recordTime
+		}
+	}
+
+	previousByClient := make(map[string]*models.Record, len(firstTimeByClient))
+	for clientUUID, firstTime := range firstTimeByClient {
+		previous, err := getPreviousTrafficRecordBefore(db, clientUUID, firstTime)
+		if err != nil {
+			return nil, err
+		}
+		if previous != nil {
+			previousByClient[clientUUID] = previous
+		}
+	}
+	return previousByClient, nil
+}
+
+func getPreviousTrafficRecordBefore(db *gorm.DB, clientUUID string, before time.Time) (*models.Record, error) {
+	var latest *models.Record
+	for _, table := range []string{"records", "records_long_term"} {
+		var record models.Record
+		queryBefore := before
+		if table == "records_long_term" {
+			queryBefore = before.Truncate(15 * time.Minute)
+		}
+		err := db.Table(table).
+			Where("client = ? AND time < ?", clientUUID, models.FromTime(queryBefore)).
+			Order("time DESC").
+			First(&record).Error
+		if err == nil {
+			if latest == nil || record.Time.ToTime().After(latest.Time.ToTime()) {
+				latest = &record
+			}
+			continue
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, err
+		}
+	}
+	return latest, nil
+}
+
+func repairZeroTrafficDeltas(records []models.Record, previousByClient map[string]*models.Record) {
+	recordsByClient := make(map[string][]*models.Record)
+	for i := range records {
+		recordsByClient[records[i].Client] = append(recordsByClient[records[i].Client], &records[i])
+	}
+
+	for _, clientRecords := range recordsByClient {
+		sort.Slice(clientRecords, func(i, j int) bool {
+			return clientRecords[i].Time.ToTime().Before(clientRecords[j].Time.ToTime())
+		})
+		var previous *models.Record
+		if previousByClient != nil {
+			previous = previousByClient[clientRecords[0].Client]
+		}
+		for _, current := range clientRecords {
+			if previous == nil {
+				previous = current
+				continue
+			}
+			if current.TrafficUp == 0 {
+				current.TrafficUp = utils.ComputeTrafficDelta(current.NetTotalUp, previous.NetTotalUp)
+			}
+			if current.TrafficDown == 0 {
+				current.TrafficDown = utils.ComputeTrafficDelta(current.NetTotalDown, previous.NetTotalDown)
+			}
+			previous = current
+		}
+	}
 }
 
 // migrateGPURecords 压缩GPU记录数据

--- a/database/records/records_test.go
+++ b/database/records/records_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
@@ -25,7 +26,8 @@ var _ = func() bool {
 // then running migrateOldRecords and verifying the aggregation and cleanup.
 func TestCompactRecord(t *testing.T) {
 	const totalMinutes = 12*60 + 30
-	now := time.Now().UTC().Truncate(time.Minute)
+	loc := models.GetAppLocation()
+	now := time.Date(2026, 6, 15, 14, 30, 0, 0, loc)
 	threshold := compactRecordCutoff(now)
 	overlapCutoff := threshold.Add(-1 * time.Hour)
 
@@ -132,7 +134,8 @@ func TestCompactRecord(t *testing.T) {
 }
 
 func TestCompactRecordPreservesExactTrafficDelta(t *testing.T) {
-	currentTime := time.Now().UTC().Truncate(time.Minute)
+	loc := models.GetAppLocation()
+	currentTime := time.Date(2026, 6, 15, 14, 30, 0, 0, loc)
 	now := currentTime.Truncate(15 * time.Minute).Add(-5*time.Hour + time.Minute)
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	assert.NoError(t, err)
@@ -174,7 +177,7 @@ func TestCompactRecordPreservesExactTrafficDelta(t *testing.T) {
 
 	var compacted []models.Record
 	assert.NoError(t, db.Table("records_long_term").Find(&compacted).Error)
-	assert.Len(t, compacted, 1)
+	require.Len(t, compacted, 1)
 	assert.Equal(t, int64(60), compacted[0].TrafficUp)
 	assert.Equal(t, int64(90), compacted[0].TrafficDown)
 	assert.Equal(t, int64(10), compacted[0].NetTotalUp)
@@ -182,8 +185,91 @@ func TestCompactRecordPreservesExactTrafficDelta(t *testing.T) {
 	assert.True(t, compacted[0].Time.ToTime().Equal(records[2].Time.ToTime().Truncate(15*time.Minute)))
 }
 
+func TestRepairZeroTrafficDeltasPreservesRawResetDetailBeforeCompaction(t *testing.T) {
+	loc := models.GetAppLocation()
+	start := time.Date(2026, 6, 6, 0, 0, 0, 0, loc)
+	records := []models.Record{
+		{Client: uuid, Time: models.FromTime(start), NetTotalUp: 100, NetTotalDown: 200},
+		{Client: uuid, Time: models.FromTime(start.Add(5 * time.Minute)), NetTotalUp: 140, NetTotalDown: 260},
+		{Client: uuid, Time: models.FromTime(start.Add(10 * time.Minute)), NetTotalUp: 10, NetTotalDown: 20},
+		{Client: uuid, Time: models.FromTime(start.Add(15 * time.Minute)), NetTotalUp: 25, NetTotalDown: 35},
+	}
+
+	repairZeroTrafficDeltas(records, nil)
+
+	assert.Equal(t, int64(0), records[0].TrafficUp)
+	assert.Equal(t, int64(0), records[0].TrafficDown)
+	assert.Equal(t, int64(40), records[1].TrafficUp)
+	assert.Equal(t, int64(60), records[1].TrafficDown)
+	assert.Equal(t, int64(10), records[2].TrafficUp)
+	assert.Equal(t, int64(20), records[2].TrafficDown)
+	assert.Equal(t, int64(15), records[3].TrafficUp)
+	assert.Equal(t, int64(15), records[3].TrafficDown)
+}
+
+func TestRepairZeroTrafficDeltasUsesPreviousPersistedBaseline(t *testing.T) {
+	loc := models.GetAppLocation()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, loc)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	assert.NoError(t, db.Table("records_long_term").Create(&models.Record{
+		Client:       uuid,
+		Time:         models.FromTime(now.Add(-10 * time.Minute)),
+		NetTotalUp:   100,
+		NetTotalDown: 200,
+	}).Error)
+
+	rawRecords := []models.Record{
+		{Client: uuid, Time: models.FromTime(now), NetTotalUp: 150, NetTotalDown: 260},
+		{Client: uuid, Time: models.FromTime(now.Add(5 * time.Minute)), NetTotalUp: 175, NetTotalDown: 300},
+	}
+
+	previousByClient, err := getPreviousTrafficRecordsBefore(db, rawRecords)
+	assert.NoError(t, err)
+	repairZeroTrafficDeltas(rawRecords, previousByClient)
+
+	assert.Equal(t, int64(50), rawRecords[0].TrafficUp)
+	assert.Equal(t, int64(60), rawRecords[0].TrafficDown)
+	assert.Equal(t, int64(25), rawRecords[1].TrafficUp)
+	assert.Equal(t, int64(40), rawRecords[1].TrafficDown)
+}
+
+func TestRepairZeroTrafficDeltasIgnoresSameSlotLongTermBaseline(t *testing.T) {
+	loc := models.GetAppLocation()
+	now := time.Date(2026, 6, 7, 12, 0, 30, 0, loc)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	assert.NoError(t, db.Table("records_long_term").Create(&models.Record{
+		Client:       uuid,
+		Time:         models.FromTime(now.Truncate(15 * time.Minute)),
+		NetTotalUp:   900,
+		NetTotalDown: 900,
+	}).Error)
+
+	rawRecords := []models.Record{
+		{Client: uuid, Time: models.FromTime(now), NetTotalUp: 150, NetTotalDown: 260},
+		{Client: uuid, Time: models.FromTime(now.Add(5 * time.Minute)), NetTotalUp: 175, NetTotalDown: 300},
+	}
+
+	previousByClient, err := getPreviousTrafficRecordsBefore(db, rawRecords)
+	assert.NoError(t, err)
+	repairZeroTrafficDeltas(rawRecords, previousByClient)
+
+	assert.Equal(t, int64(0), rawRecords[0].TrafficUp)
+	assert.Equal(t, int64(0), rawRecords[0].TrafficDown)
+	assert.Equal(t, int64(25), rawRecords[1].TrafficUp)
+	assert.Equal(t, int64(40), rawRecords[1].TrafficDown)
+}
+
 func TestCompactRecordRetainsOneHourOverlapWindow(t *testing.T) {
-	now := time.Date(2026, 6, 7, 12, 7, 0, 0, time.UTC)
+	loc := models.GetAppLocation()
+	now := time.Date(2026, 6, 7, 12, 7, 0, 0, loc)
 	cutoff := compactRecordCutoff(now)
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	assert.NoError(t, err)
@@ -203,13 +289,14 @@ func TestCompactRecordRetainsOneHourOverlapWindow(t *testing.T) {
 
 	var remainTimes []models.Record
 	assert.NoError(t, db.Table("records").Order("time ASC").Find(&remainTimes).Error)
-	assert.Len(t, remainTimes, 2)
+	require.Len(t, remainTimes, 2)
 	assert.True(t, remainTimes[0].Time.ToTime().Equal(records[1].Time.ToTime()))
 	assert.True(t, remainTimes[1].Time.ToTime().Equal(records[2].Time.ToTime()))
 }
 
 func TestCompactRecordOnlyMigratesCompleteFifteenMinuteBuckets(t *testing.T) {
-	now := time.Date(2026, 6, 7, 12, 7, 0, 0, time.UTC)
+	loc := models.GetAppLocation()
+	now := time.Date(2026, 6, 7, 12, 7, 0, 0, loc)
 	cutoff := compactRecordCutoff(now)
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	assert.NoError(t, err)
@@ -225,7 +312,7 @@ func TestCompactRecordOnlyMigratesCompleteFifteenMinuteBuckets(t *testing.T) {
 
 	var compacted []models.Record
 	assert.NoError(t, db.Table("records_long_term").Order("time ASC").Find(&compacted).Error)
-	assert.Len(t, compacted, 1)
+	require.Len(t, compacted, 1)
 	assert.True(t, compacted[0].Time.ToTime().Equal(compactable.Time.ToTime().Truncate(15*time.Minute)))
 
 	var rawCount int64

--- a/utils/notifier/traffic_report.go
+++ b/utils/notifier/traffic_report.go
@@ -1,8 +1,10 @@
 package notifier
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	messageevent "github.com/komari-monitor/komari/database/models/messageEvent"
 	"github.com/komari-monitor/komari/pkg/config"
 	"github.com/komari-monitor/komari/pkg/corn"
+	"github.com/komari-monitor/komari/utils"
 	"github.com/komari-monitor/komari/utils/messageSender"
 	"gorm.io/gorm"
 )
@@ -173,49 +176,135 @@ func getClientTrafficInRange(clientUUID string, trafficType string, start, end t
 	return getClientTrafficInRangeWithDB(dbcore.GetDBInstance(), clientUUID, trafficType, start, end)
 }
 
-func getClientTrafficInRangeWithDB(db *gorm.DB, clientUUID string, trafficType string, start, end time.Time) (int64, error) {
-	type trafficDeltaRecord struct {
-		Time        models.LocalTime `gorm:"column:time"`
-		TrafficUp   int64            `gorm:"column:traffic_up"`
-		TrafficDown int64            `gorm:"column:traffic_down"`
-	}
+type trafficDeltaRecord struct {
+	Time         models.LocalTime `gorm:"column:time"`
+	NetTotalUp   int64            `gorm:"column:net_total_up"`
+	NetTotalDown int64            `gorm:"column:net_total_down"`
+	TrafficUp    int64            `gorm:"column:traffic_up"`
+	TrafficDown  int64            `gorm:"column:traffic_down"`
+}
 
+func getClientTrafficInRangeWithDB(db *gorm.DB, clientUUID string, trafficType string, start, end time.Time) (int64, error) {
 	var recentRecords []trafficDeltaRecord
 	if err := db.Table("records").
-		Select("time, traffic_up, traffic_down").
-		Where("client = ? AND time >= ? AND time <= ?", clientUUID, start, end).
+		Select("time, net_total_up, net_total_down, traffic_up, traffic_down").
+		Where("client = ? AND time >= ? AND time <= ?", clientUUID, models.FromTime(start), models.FromTime(end)).
 		Find(&recentRecords).Error; err != nil {
 		return 0, err
 	}
 
 	var longTermRecords []trafficDeltaRecord
 	if err := db.Table("records_long_term").
-		Select("time, traffic_up, traffic_down").
-		Where("client = ? AND time >= ? AND time <= ?", clientUUID, start, end).
+		Select("time, net_total_up, net_total_down, traffic_up, traffic_down").
+		Where("client = ? AND time >= ? AND time <= ?", clientUUID, models.FromTime(start), models.FromTime(end)).
 		Find(&longTermRecords).Error; err != nil {
 		return 0, err
 	}
 
-	var totalUp int64
-	var totalDown int64
-	longTermSlots := make(map[time.Time]struct{}, len(longTermRecords))
+	records := mergeTrafficRecords(recentRecords, longTermRecords)
 
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].Time.ToTime().Before(records[j].Time.ToTime())
+	})
+
+	previous, err := getPreviousTrafficDeltaRecord(db, clientUUID, start)
+	if err != nil {
+		return 0, err
+	}
+
+	totalUp, totalDown := sumTrafficDeltas(records, previous)
+	return computeUsedByType(strings.ToLower(trafficType), totalUp, totalDown), nil
+}
+
+func mergeTrafficRecords(recentRecords, longTermRecords []trafficDeltaRecord) []trafficDeltaRecord {
+	rawSlots := make(map[time.Time]struct{}, len(recentRecords))
+	for _, record := range recentRecords {
+		rawSlots[record.Time.ToTime().Truncate(15*time.Minute)] = struct{}{}
+	}
+
+	longTermSlots := make(map[time.Time]struct{}, len(longTermRecords))
+	records := make([]trafficDeltaRecord, 0, len(longTermRecords)+len(recentRecords))
 	for _, record := range longTermRecords {
-		totalUp += record.TrafficUp
-		totalDown += record.TrafficDown
-		longTermSlots[record.Time.ToTime()] = struct{}{}
+		slot := record.Time.ToTime().Truncate(15 * time.Minute)
+		if _, hasRawSlot := rawSlots[slot]; hasRawSlot && record.TrafficUp == 0 && record.TrafficDown == 0 {
+			continue
+		}
+		longTermSlots[slot] = struct{}{}
+		records = append(records, record)
 	}
 
 	for _, record := range recentRecords {
-		// records_long_term stores one aggregated row per 15-minute slot.
-		// Skip raw rows only when that exact slot is already present there.
 		slot := record.Time.ToTime().Truncate(15 * time.Minute)
 		if _, exists := longTermSlots[slot]; exists {
 			continue
 		}
-		totalUp += record.TrafficUp
-		totalDown += record.TrafficDown
+		records = append(records, record)
 	}
 
-	return computeUsedByType(strings.ToLower(trafficType), totalUp, totalDown), nil
+	return records
+}
+
+func getPreviousTrafficDeltaRecord(db *gorm.DB, clientUUID string, before time.Time) (*trafficDeltaRecord, error) {
+	record, err := latestTrafficDeltaRecordBefore(db.Table("records"), clientUUID, before)
+	if err != nil {
+		return nil, err
+	}
+
+	longTermRecord, err := latestTrafficDeltaRecordBefore(db.Table("records_long_term"), clientUUID, before)
+	if err != nil {
+		return nil, err
+	}
+
+	if record == nil {
+		return longTermRecord, nil
+	}
+	if longTermRecord == nil {
+		return record, nil
+	}
+	if longTermRecord.Time.ToTime().After(record.Time.ToTime()) {
+		return longTermRecord, nil
+	}
+	return record, nil
+}
+
+func latestTrafficDeltaRecordBefore(query *gorm.DB, clientUUID string, before time.Time) (*trafficDeltaRecord, error) {
+	var record trafficDeltaRecord
+	err := query.
+		Select("time, net_total_up, net_total_down, traffic_up, traffic_down").
+		Where("client = ? AND time < ?", clientUUID, models.FromTime(before)).
+		Order("time DESC").
+		First(&record).Error
+	if err == nil {
+		return &record, nil
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	return nil, err
+}
+
+func sumTrafficDeltas(records []trafficDeltaRecord, previous *trafficDeltaRecord) (int64, int64) {
+	var totalUp int64
+	var totalDown int64
+
+	for i := range records {
+		up := records[i].TrafficUp
+		down := records[i].TrafficDown
+		if previous != nil {
+			up = trafficDeltaOrFallback(up, records[i].NetTotalUp, previous.NetTotalUp)
+			down = trafficDeltaOrFallback(down, records[i].NetTotalDown, previous.NetTotalDown)
+		}
+		totalUp += up
+		totalDown += down
+		previous = &records[i]
+	}
+
+	return totalUp, totalDown
+}
+
+func trafficDeltaOrFallback(storedDelta, currentTotal, previousTotal int64) int64 {
+	if storedDelta > 0 {
+		return storedDelta
+	}
+	return utils.ComputeTrafficDelta(currentTotal, previousTotal)
 }

--- a/utils/notifier/traffic_report_test.go
+++ b/utils/notifier/traffic_report_test.go
@@ -41,6 +41,37 @@ func TestGetClientTrafficInRangeAvoidsOverlappingRawAndLongTermRows(t *testing.T
 	assert.Equal(t, int64(380), used)
 }
 
+func TestGetClientTrafficInRangeNormalizesLongTermSlotForOverlap(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	clientUUID := "client-overlap-normalized"
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	sharedSlot := start.Add(15 * time.Minute)
+
+	assert.NoError(t, db.Table("records_long_term").Create(&models.Record{
+		Client:      clientUUID,
+		Time:        models.FromTime(sharedSlot.Add(8 * time.Minute)),
+		TrafficUp:   100,
+		TrafficDown: 200,
+	}).Error)
+
+	rawRecords := []models.Record{
+		{Client: clientUUID, Time: models.FromTime(sharedSlot.Add(1 * time.Minute)), TrafficUp: 40, TrafficDown: 80},
+		{Client: clientUUID, Time: models.FromTime(sharedSlot.Add(5 * time.Minute)), TrafficUp: 60, TrafficDown: 120},
+		{Client: clientUUID, Time: models.FromTime(sharedSlot.Add(16 * time.Minute)), TrafficUp: 30, TrafficDown: 50},
+	}
+	for _, record := range rawRecords {
+		assert.NoError(t, db.Create(&record).Error)
+	}
+
+	used, err := getClientTrafficInRangeWithDB(db, clientUUID, "sum", start, sharedSlot.Add(30*time.Minute))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(380), used)
+}
+
 func TestGetClientTrafficInRangeSumsPersistedDeltasAcrossCounterReset(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	assert.NoError(t, err)
@@ -62,4 +93,95 @@ func TestGetClientTrafficInRangeSumsPersistedDeltasAcrossCounterReset(t *testing
 	used, err := getClientTrafficInRangeWithDB(db, clientUUID, "sum", start, start.Add(20*time.Minute))
 	assert.NoError(t, err)
 	assert.Equal(t, int64(175), used)
+}
+
+func TestGetClientTrafficInRangeFallsBackForPersistedZeroDeltas(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	clientUUID := "client-zero-deltas"
+	start := time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
+	records := []models.Record{
+		{Client: clientUUID, Time: models.FromTime(start.Add(-5 * time.Minute)), NetTotalUp: 100, NetTotalDown: 200},
+		{Client: clientUUID, Time: models.FromTime(start.Add(0 * time.Minute)), NetTotalUp: 130, NetTotalDown: 250},
+		{Client: clientUUID, Time: models.FromTime(start.Add(5 * time.Minute)), NetTotalUp: 160, NetTotalDown: 310},
+		{Client: clientUUID, Time: models.FromTime(start.Add(10 * time.Minute)), NetTotalUp: 10, NetTotalDown: 30},
+		{Client: clientUUID, Time: models.FromTime(start.Add(15 * time.Minute)), NetTotalUp: 25, NetTotalDown: 40},
+	}
+	for _, record := range records {
+		assert.NoError(t, db.Create(&record).Error)
+	}
+
+	used, err := getClientTrafficInRangeWithDB(db, clientUUID, "sum", start, start.Add(20*time.Minute))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(235), used)
+}
+
+func TestGetClientTrafficInRangeFallsBackForLongTermZeroDeltas(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	clientUUID := "client-long-term-zero-deltas"
+	start := time.Date(2026, 6, 4, 0, 0, 0, 0, time.UTC)
+	assert.NoError(t, db.Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(start.Add(-15 * time.Minute)),
+		NetTotalUp:   100,
+		NetTotalDown: 200,
+	}).Error)
+
+	longTermRecords := []models.Record{
+		{Client: clientUUID, Time: models.FromTime(start), NetTotalUp: 140, NetTotalDown: 260},
+		{Client: clientUUID, Time: models.FromTime(start.Add(15 * time.Minute)), NetTotalUp: 180, NetTotalDown: 330},
+	}
+	for _, record := range longTermRecords {
+		assert.NoError(t, db.Table("records_long_term").Create(&record).Error)
+	}
+
+	used, err := getClientTrafficInRangeWithDB(db, clientUUID, "sum", start, start.Add(30*time.Minute))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(210), used)
+}
+
+func TestGetClientTrafficInRangePrefersRawSlotOverZeroLongTermSlot(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	clientUUID := "client-zero-long-term-with-raw-reset"
+	start := time.Date(2026, 6, 5, 0, 0, 0, 0, time.UTC)
+	slot := start.Add(15 * time.Minute)
+	assert.NoError(t, db.Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(start.Add(-5 * time.Minute)),
+		NetTotalUp:   100,
+		NetTotalDown: 200,
+	}).Error)
+
+	assert.NoError(t, db.Table("records_long_term").Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(slot),
+		NetTotalUp:   15,
+		NetTotalDown: 25,
+		TrafficUp:    0,
+		TrafficDown:  0,
+	}).Error)
+
+	rawRecords := []models.Record{
+		{Client: clientUUID, Time: models.FromTime(slot.Add(1 * time.Minute)), NetTotalUp: 130, NetTotalDown: 240},
+		{Client: clientUUID, Time: models.FromTime(slot.Add(5 * time.Minute)), NetTotalUp: 10, NetTotalDown: 20},
+		{Client: clientUUID, Time: models.FromTime(slot.Add(10 * time.Minute)), NetTotalUp: 15, NetTotalDown: 25},
+	}
+	for _, record := range rawRecords {
+		assert.NoError(t, db.Create(&record).Error)
+	}
+
+	used, err := getClientTrafficInRangeWithDB(db, clientUUID, "sum", start, slot.Add(15*time.Minute))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(110), used)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/komari-monitor/komari/protocol/v1"
 	"github.com/komari-monitor/komari/database/models"
+	"github.com/komari-monitor/komari/protocol/v1"
 )
 
 // AverageReport 根据 topPercentage 参数计算报告的平均值。
@@ -25,6 +25,8 @@ func AverageReport(uuid string, time time.Time, records []v1.Report, topPercenta
 			recordsToAverageCount = 1 // 确保至少选择一个记录，除非总数为0
 		}
 	}
+
+	latestTotalUp, latestTotalDown := latestNetworkTotals(records)
 
 	// 定义一个辅助函数，用于排序和求和
 	sumAndSort := func(getFloat32Value func(v1.Report) float32, getInt64Value func(v1.Report) int64, isFloat bool) (float32, int64) {
@@ -120,13 +122,37 @@ func AverageReport(uuid string, time time.Time, records []v1.Report, topPercenta
 		DiskTotal:      records[0].Disk.Total,
 		NetIn:          sumNETIn / int64(recordsToAverageCount),
 		NetOut:         sumNETOut / int64(recordsToAverageCount),
-		NetTotalUp:     sumNETTotalUp / int64(recordsToAverageCount),
-		NetTotalDown:   sumNETTotalDown / int64(recordsToAverageCount),
+		NetTotalUp:     latestTotalUp,
+		NetTotalDown:   latestTotalDown,
 		Process:        sumPROCESS / recordsToAverageCount,
 		Connections:    sumConnections / recordsToAverageCount,
 		ConnectionsUdp: sumConnectionsUDP / recordsToAverageCount,
 	}
 	return newRecord
+}
+
+func latestNetworkTotals(records []v1.Report) (int64, int64) {
+	if len(records) == 0 {
+		return 0, 0
+	}
+	latestIndex := 0
+	for i := 1; i < len(records); i++ {
+		if records[i].UpdatedAt.After(records[latestIndex].UpdatedAt) ||
+			records[i].UpdatedAt.Equal(records[latestIndex].UpdatedAt) {
+			latestIndex = i
+		}
+	}
+	return records[latestIndex].Network.TotalUp, records[latestIndex].Network.TotalDown
+}
+
+func ComputeTrafficDelta(current, previous int64) int64 {
+	if current < 0 || previous < 0 {
+		return 0
+	}
+	if current >= previous {
+		return current - previous
+	}
+	return current
 }
 
 // AverageGPUReports 使用与 AverageReport 相同的聚合逻辑处理GPU数据

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/komari-monitor/komari/protocol/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAverageReportUsesLatestNetworkTotals(t *testing.T) {
+	base := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	record := AverageReport("client-latest-total", base.Add(time.Minute), []v1.Report{
+		{
+			UpdatedAt: base.Add(10 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 300, TotalDown: 500},
+		},
+		{
+			UpdatedAt: base.Add(50 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 360, TotalDown: 620},
+		},
+	}, 0)
+
+	assert.Equal(t, int64(360), record.NetTotalUp)
+	assert.Equal(t, int64(620), record.NetTotalDown)
+}
+
+func TestComputeTrafficDelta(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  int64
+		previous int64
+		want     int64
+	}{
+		{name: "previous zero counts current delta", current: 120, previous: 0, want: 120},
+		{name: "monotonic counter uses difference", current: 250, previous: 200, want: 50},
+		{name: "same counter", current: 100, previous: 100, want: 0},
+		{name: "counter reset uses current", current: 15, previous: 250, want: 15},
+		{name: "negative current remains guarded", current: -1, previous: 100, want: 0},
+		{name: "negative previous remains guarded", current: 15, previous: -1, want: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, ComputeTrafficDelta(test.current, test.previous))
+		})
+	}
+}

--- a/web/api/client/ingest.go
+++ b/web/api/client/ingest.go
@@ -18,11 +18,11 @@ import (
 // markPresence 为 true 时按 POST 上报会话刷新在线状态（WS 连接自行管理在线状态，应传 false）。
 func ingestReport(uuid string, report v1.Report, protocolVersion int, markPresence bool) error {
 	report.UUID = uuid
-	report.UpdatedAt = time.Now()
-	if err := SaveClientReport(uuid, report); err != nil {
+	savedReport, err := SaveClientReport(uuid, report)
+	if err != nil {
 		return err
 	}
-	agent_runtime.SetLatestReport(uuid, &report)
+	agent_runtime.SetLatestReport(uuid, &savedReport)
 	agent_runtime.SetClientProtocolVersion(uuid, protocolVersion)
 	if markPresence {
 		refreshPostPresence(uuid)

--- a/web/api/client/report.go
+++ b/web/api/client/report.go
@@ -20,7 +20,6 @@ import (
 	"github.com/komari-monitor/komari/web/api"
 	"github.com/komari-monitor/komari/web/connection"
 	report_cache "github.com/komari-monitor/komari/web/report"
-	"github.com/patrickmn/go-cache"
 )
 
 const (
@@ -119,8 +118,6 @@ func UploadReport(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
 		return
 	}
-	report.UpdatedAt = time.Now()
-
 	// 优先使用 body 中的 UUID，若为空则从中间件注入的上下文中获取
 	uuid := report.UUID
 	if uuid == "" {
@@ -266,16 +263,9 @@ func processMessage(conn *connection.SafeConn, message []byte, uuid string) {
 	}
 }
 
-func SaveClientReport(uuid string, report v1.Report) error {
-	reports, _ := report_cache.Records.Get(uuid)
-	if reports == nil {
-		reports = []v1.Report{}
-	}
+func SaveClientReport(uuid string, report v1.Report) (v1.Report, error) {
 	if report.CPU.Usage < 0.01 {
 		report.CPU.Usage = 0.01
 	}
-	reports = append(reports.([]v1.Report), report)
-	report_cache.Records.Set(uuid, reports, cache.DefaultExpiration)
-
-	return nil
+	return report_cache.AppendClientReport(uuid, report)
 }

--- a/web/nezha/compat.go
+++ b/web/nezha/compat.go
@@ -349,14 +349,17 @@ func ingestState(uuid string, st *proto.State) error {
 			TotalUp:   int64(st.NetOutTransfer),
 			TotalDown: int64(st.NetInTransfer),
 		},
-		Uptime:    int64(st.Uptime),
-		Process:   int(st.ProcessCount),
-		UpdatedAt: time.Now(),
+		Uptime:  int64(st.Uptime),
+		Process: int(st.ProcessCount),
+	}
+	// 写入内存缓存，入库交由定时聚合任务处理
+	savedReport, err := apiClient.SaveClientReport(uuid, rep)
+	if err != nil {
+		return err
 	}
 	// 更新实时缓存供前端使用
-	agent_runtime.SetLatestReport(uuid, &rep)
-	// 写入内存缓存，入库交由定时聚合任务处理
-	return apiClient.SaveClientReport(uuid, rep)
+	agent_runtime.SetLatestReport(uuid, &savedReport)
+	return nil
 }
 
 // ReportGeoIP: 保存 Agent 上报的 IP，并回填国家码/面板启动时间

--- a/web/report/cache.go
+++ b/web/report/cache.go
@@ -1,64 +1,113 @@
 package report
 
 import (
+	"fmt"
 	"log"
+	"sort"
 	"strconv"
+	"sync"
 	"time"
 
+	"github.com/komari-monitor/komari/database/clients"
 	"github.com/komari-monitor/komari/database/dbcore"
 	"github.com/komari-monitor/komari/database/models"
 	"github.com/komari-monitor/komari/protocol/v1"
 	"github.com/komari-monitor/komari/utils"
 	"github.com/patrickmn/go-cache"
+	"gorm.io/gorm"
 )
 
 var Records = cache.New(1*time.Minute, 1*time.Minute)
+var reportCacheMu sync.Mutex
+var saveClientReportMu sync.Mutex
+
+func AppendClientReport(uuid string, report v1.Report) (v1.Report, error) {
+	reportCacheMu.Lock()
+	defer reportCacheMu.Unlock()
+
+	reports, ok := cachedReports(uuid)
+	if !ok {
+		return v1.Report{}, fmt.Errorf("invalid report type for UUID %s", uuid)
+	}
+	report.UUID = uuid
+	report.UpdatedAt = time.Now()
+	reports = append(reports, report)
+	Records.Set(uuid, reports, cache.DefaultExpiration)
+	return report, nil
+}
 
 func SaveClientReportToDB() error {
-	lastMinute := time.Now().Add(-time.Minute).Unix()
+	return saveClientReportToDB(dbcore.GetDBInstance(), time.Now())
+}
+
+func saveClientReportToDB(db *gorm.DB, now time.Time) error {
+	saveClientReportMu.Lock()
+	defer saveClientReportMu.Unlock()
+
+	lastMinute := now.Add(-time.Minute).Unix()
 	var records []models.Record
 	var gpuRecords []models.GPURecord
+	trafficByRecord := make(map[string]cachedTrafficSummary)
 
+	reportCacheMu.Lock()
 	for uuid, x := range Records.Items() {
-		if uuid == "" {
-			continue
-		}
-
-		reports, ok := x.Object.([]v1.Report)
-		if !ok {
-			log.Printf("Invalid report type for UUID %s", uuid)
-			continue
-		}
-
-		var filtered []v1.Report
-		for _, r := range reports {
-			if r.UpdatedAt.Unix() >= lastMinute {
-				filtered = append(filtered, r)
+		func() {
+			if uuid == "" {
+				return
 			}
-		}
 
-		Records.Set(uuid, filtered, cache.DefaultExpiration)
+			reports, ok := x.Object.([]v1.Report)
+			if !ok {
+				log.Printf("Invalid report type for UUID %s", uuid)
+				return
+			}
 
-		if len(filtered) > 0 {
-			r := utils.AverageReport(uuid, time.Now(), filtered, 0.3)
-			records = append(records, r)
-			gpuRecords = append(gpuRecords, utils.AverageGPUReports(uuid, time.Now(), filtered, 0.3)...)
-		}
+			var filtered []v1.Report
+			for _, r := range reports {
+				if r.UpdatedAt.Unix() >= lastMinute {
+					if err := clients.ReportVerify(r); err != nil {
+						log.Printf("Invalid report data for UUID %s: %v", uuid, err)
+						continue
+					}
+					filtered = append(filtered, r)
+				}
+			}
+
+			Records.Set(uuid, filtered, cache.DefaultExpiration)
+
+			if len(filtered) > 0 {
+				r := utils.AverageReport(uuid, now, filtered, 0.3)
+				key := recordDedupKey(r)
+				trafficByRecord[key] = summarizeCachedTraffic(filtered)
+				records = append(records, r)
+				gpuRecords = append(gpuRecords, utils.AverageGPUReports(uuid, now, filtered, 0.3)...)
+			}
+		}()
 	}
-
-	db := dbcore.GetDBInstance()
+	reportCacheMu.Unlock()
 
 	if len(records) > 0 {
 		unique := make(map[string]models.Record)
 		for _, rec := range records {
-			key := rec.Client + "_" + strconv.FormatInt(rec.Time.ToTime().Unix(), 10)
-			unique[key] = rec
+			unique[recordDedupKey(rec)] = rec
 		}
 		var deduped []models.Record
-		for _, rec := range unique {
+		dedupedTraffic := make(map[string]cachedTrafficSummary, len(unique))
+		for key, rec := range unique {
 			deduped = append(deduped, rec)
+			if summary, ok := trafficByRecord[key]; ok {
+				dedupedTraffic[key] = summary
+			}
 		}
-		if err := db.Model(&models.Record{}).Create(&deduped).Error; err != nil {
+		if err := db.Transaction(func(tx *gorm.DB) error {
+			if err := fillTrafficDeltas(tx, deduped, dedupedTraffic); err != nil {
+				return err
+			}
+			if err := tx.Model(&models.Record{}).Create(&deduped).Error; err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
 			log.Printf("Failed to save records to database: %v", err)
 			return err
 		}
@@ -81,4 +130,169 @@ func SaveClientReportToDB() error {
 	}
 
 	return nil
+}
+
+func cachedReports(uuid string) ([]v1.Report, bool) {
+	cached, ok := Records.Get(uuid)
+	if !ok || cached == nil {
+		return []v1.Report{}, true
+	}
+	reports, ok := cached.([]v1.Report)
+	return reports, ok
+}
+
+func recordDedupKey(rec models.Record) string {
+	return rec.Client + "_" + strconv.FormatInt(rec.Time.ToTime().Unix(), 10)
+}
+
+type trafficTotalPoint struct {
+	Time      time.Time
+	TotalUp   int64
+	TotalDown int64
+}
+
+type cachedTrafficSummary struct {
+	Points []trafficTotalPoint
+}
+
+func summarizeCachedTraffic(reports []v1.Report) cachedTrafficSummary {
+	points := make([]trafficTotalPoint, 0, len(reports))
+	for _, report := range reports {
+		points = append(points, trafficTotalPoint{
+			Time:      report.UpdatedAt,
+			TotalUp:   report.Network.TotalUp,
+			TotalDown: report.Network.TotalDown,
+		})
+	}
+	sort.SliceStable(points, func(i, j int) bool {
+		return points[i].Time.Before(points[j].Time)
+	})
+	return cachedTrafficSummary{Points: points}
+}
+
+type previousTrafficRecord struct {
+	Client       string           `gorm:"column:client"`
+	Time         models.LocalTime `gorm:"column:time"`
+	NetTotalUp   int64            `gorm:"column:net_total_up"`
+	NetTotalDown int64            `gorm:"column:net_total_down"`
+}
+
+func fillTrafficDeltas(db *gorm.DB, records []models.Record, trafficByRecord map[string]cachedTrafficSummary) error {
+	recordsByTime := make(map[time.Time][]int)
+	for i := range records {
+		before := records[i].Time.ToTime().Round(0)
+		recordsByTime[before] = append(recordsByTime[before], i)
+	}
+
+	for before, indexes := range recordsByTime {
+		clientUUIDs := make([]string, 0, len(indexes))
+		seen := make(map[string]struct{}, len(indexes))
+		for _, index := range indexes {
+			clientUUID := records[index].Client
+			if clientUUID == "" {
+				continue
+			}
+			if _, exists := seen[clientUUID]; exists {
+				continue
+			}
+			seen[clientUUID] = struct{}{}
+			clientUUIDs = append(clientUUIDs, clientUUID)
+		}
+
+		previousByClient, err := getLatestTrafficRecordsBefore(db, clientUUIDs, before)
+		if err != nil {
+			return fmt.Errorf("load previous traffic records before %s: %w", before.Format(time.RFC3339), err)
+		}
+
+		for _, index := range indexes {
+			key := recordDedupKey(records[index])
+			if summary, ok := trafficByRecord[key]; ok && len(summary.Points) > 0 {
+				if previous, exists := previousByClient[records[index].Client]; exists {
+					records[index].TrafficUp, records[index].TrafficDown = sumCachedTrafficDeltas(summary, &previous)
+				} else {
+					records[index].TrafficUp, records[index].TrafficDown = sumCachedTrafficDeltas(summary, nil)
+				}
+				continue
+			}
+
+			previous, exists := previousByClient[records[index].Client]
+			if !exists {
+				continue
+			}
+			records[index].TrafficUp = utils.ComputeTrafficDelta(records[index].NetTotalUp, previous.NetTotalUp)
+			records[index].TrafficDown = utils.ComputeTrafficDelta(records[index].NetTotalDown, previous.NetTotalDown)
+		}
+	}
+
+	return nil
+}
+
+func sumCachedTrafficDeltas(summary cachedTrafficSummary, previous *previousTrafficRecord) (int64, int64) {
+	if len(summary.Points) == 0 {
+		return 0, 0
+	}
+
+	startIndex := 0
+	var previousUp int64
+	var previousDown int64
+	var previousTime time.Time
+	if previous != nil {
+		previousUp = previous.NetTotalUp
+		previousDown = previous.NetTotalDown
+		previousTime = previous.Time.ToTime()
+	} else {
+		previousUp = summary.Points[0].TotalUp
+		previousDown = summary.Points[0].TotalDown
+		previousTime = summary.Points[0].Time
+		startIndex = 1
+	}
+
+	var totalUp int64
+	var totalDown int64
+	for _, point := range summary.Points[startIndex:] {
+		if !point.Time.After(previousTime) {
+			continue
+		}
+		totalUp += utils.ComputeTrafficDelta(point.TotalUp, previousUp)
+		totalDown += utils.ComputeTrafficDelta(point.TotalDown, previousDown)
+		previousUp = point.TotalUp
+		previousDown = point.TotalDown
+		previousTime = point.Time
+	}
+	return totalUp, totalDown
+}
+
+func getLatestTrafficRecordsBefore(db *gorm.DB, clientUUIDs []string, before time.Time) (map[string]previousTrafficRecord, error) {
+	previousByClient := make(map[string]previousTrafficRecord, len(clientUUIDs))
+	if len(clientUUIDs) == 0 {
+		return previousByClient, nil
+	}
+
+	for _, table := range []string{"records", "records_long_term"} {
+		records, err := latestTrafficRecordsBeforeFromTable(db, table, clientUUIDs, before)
+		if err != nil {
+			return nil, err
+		}
+		for _, record := range records {
+			previous, exists := previousByClient[record.Client]
+			if !exists || record.Time.ToTime().After(previous.Time.ToTime()) {
+				previousByClient[record.Client] = record
+			}
+		}
+	}
+	return previousByClient, nil
+}
+
+func latestTrafficRecordsBeforeFromTable(db *gorm.DB, table string, clientUUIDs []string, before time.Time) ([]previousTrafficRecord, error) {
+	var records []previousTrafficRecord
+	latestPerClient := db.Table(table).
+		Select("client, MAX(time) AS time").
+		Where("client IN ? AND time < ?", clientUUIDs, models.FromTime(before)).
+		Group("client")
+
+	err := db.Table(table+" AS r").
+		Select("r.client, r.time, r.net_total_up, r.net_total_down").
+		Joins("JOIN (?) AS latest ON latest.client = r.client AND latest.time = r.time", latestPerClient).
+		Find(&records).Error
+	return records, err
 }

--- a/web/report/cache_test.go
+++ b/web/report/cache_test.go
@@ -1,0 +1,346 @@
+package report
+
+import (
+	"testing"
+	"time"
+
+	"github.com/komari-monitor/komari/database/models"
+	"github.com/komari-monitor/komari/protocol/v1"
+	"github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func openReportCacheTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Record{}))
+	require.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+	require.NoError(t, db.AutoMigrate(&models.GPURecord{}))
+	return db
+}
+
+func resetReportCache(t *testing.T) {
+	t.Helper()
+	Records.Flush()
+	t.Cleanup(func() {
+		Records.Flush()
+	})
+}
+
+func TestAppendClientReportSerializesCacheMutation(t *testing.T) {
+	resetReportCache(t)
+
+	clientUUID := "client-append-helper"
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+
+	first, err := AppendClientReport(clientUUID, v1.Report{
+		UpdatedAt: now.Add(-10 * time.Second),
+		Network:   v1.NetworkReport{TotalUp: 100, TotalDown: 200},
+	})
+	require.NoError(t, err)
+	second, err := AppendClientReport(clientUUID, v1.Report{
+		UpdatedAt: now.Add(-5 * time.Second),
+		Network:   v1.NetworkReport{TotalUp: 150, TotalDown: 260},
+	})
+	require.NoError(t, err)
+
+	cached, ok := Records.Get(clientUUID)
+	require.True(t, ok)
+	reports, ok := cached.([]v1.Report)
+	require.True(t, ok)
+	require.Len(t, reports, 2)
+	assert.Equal(t, int64(100), reports[0].Network.TotalUp)
+	assert.Equal(t, int64(150), reports[1].Network.TotalUp)
+	assert.Equal(t, first.UpdatedAt, reports[0].UpdatedAt)
+	assert.Equal(t, second.UpdatedAt, reports[1].UpdatedAt)
+	assert.True(t, reports[0].UpdatedAt.After(now.Add(-10*time.Second)))
+	assert.True(t, reports[1].UpdatedAt.After(now.Add(-5*time.Second)))
+}
+
+func TestAppendClientReportRejectsCorruptedCacheValue(t *testing.T) {
+	resetReportCache(t)
+
+	Records.Set("client-bad-cache", "not reports", cache.DefaultExpiration)
+
+	_, err := AppendClientReport("client-bad-cache", v1.Report{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid report type")
+}
+
+func TestSaveClientReportToDBStoresCachedTrafficDelta(t *testing.T) {
+	resetReportCache(t)
+	db := openReportCacheTestDB(t)
+
+	clientUUID := "client-cached-delta"
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(now.Add(-2 * time.Minute)),
+		NetTotalUp:   100,
+		NetTotalDown: 200,
+	}).Error)
+
+	Records.Set(clientUUID, []v1.Report{
+		{
+			UpdatedAt: now.Add(-30 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 130, TotalDown: 260},
+		},
+		{
+			UpdatedAt: now.Add(-10 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 175, TotalDown: 320},
+		},
+	}, cache.DefaultExpiration)
+
+	require.NoError(t, saveClientReportToDB(db, now))
+
+	var saved models.Record
+	require.NoError(t, db.Where("client = ? AND time = ?", clientUUID, models.FromTime(now)).First(&saved).Error)
+	assert.Equal(t, int64(175), saved.NetTotalUp)
+	assert.Equal(t, int64(320), saved.NetTotalDown)
+	assert.Equal(t, int64(75), saved.TrafficUp)
+	assert.Equal(t, int64(120), saved.TrafficDown)
+}
+
+func TestSaveClientReportToDBStoresCachedTrafficDeltaAfterCounterReset(t *testing.T) {
+	resetReportCache(t)
+	db := openReportCacheTestDB(t)
+
+	clientUUID := "client-cached-reset"
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(now.Add(-2 * time.Minute)),
+		NetTotalUp:   500,
+		NetTotalDown: 700,
+	}).Error)
+
+	Records.Set(clientUUID, []v1.Report{
+		{
+			UpdatedAt: now.Add(-20 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 30, TotalDown: 45},
+		},
+		{
+			UpdatedAt: now.Add(-5 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 40, TotalDown: 55},
+		},
+	}, cache.DefaultExpiration)
+
+	require.NoError(t, saveClientReportToDB(db, now))
+
+	var saved models.Record
+	require.NoError(t, db.Where("client = ? AND time = ?", clientUUID, models.FromTime(now)).First(&saved).Error)
+	assert.Equal(t, int64(40), saved.NetTotalUp)
+	assert.Equal(t, int64(55), saved.NetTotalDown)
+	assert.Equal(t, int64(40), saved.TrafficUp)
+	assert.Equal(t, int64(55), saved.TrafficDown)
+}
+
+func TestSaveClientReportToDBSumsCachedTrafficWithoutPersistedBaseline(t *testing.T) {
+	resetReportCache(t)
+	db := openReportCacheTestDB(t)
+
+	clientUUID := "client-cached-no-baseline"
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	Records.Set(clientUUID, []v1.Report{
+		{
+			UpdatedAt: now.Add(-40 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 100, TotalDown: 200},
+		},
+		{
+			UpdatedAt: now.Add(-20 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 130, TotalDown: 250},
+		},
+		{
+			UpdatedAt: now.Add(-5 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 155, TotalDown: 280},
+		},
+	}, cache.DefaultExpiration)
+
+	require.NoError(t, saveClientReportToDB(db, now))
+
+	var saved models.Record
+	require.NoError(t, db.Where("client = ? AND time = ?", clientUUID, models.FromTime(now)).First(&saved).Error)
+	assert.Equal(t, int64(155), saved.NetTotalUp)
+	assert.Equal(t, int64(280), saved.NetTotalDown)
+	assert.Equal(t, int64(55), saved.TrafficUp)
+	assert.Equal(t, int64(80), saved.TrafficDown)
+}
+
+func TestSaveClientReportToDBSumsCachedTrafficAcrossIntraMinuteReset(t *testing.T) {
+	resetReportCache(t)
+	db := openReportCacheTestDB(t)
+
+	clientUUID := "client-cached-intra-minute-reset"
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(now.Add(-2 * time.Minute)),
+		NetTotalUp:   500,
+		NetTotalDown: 700,
+	}).Error)
+
+	Records.Set(clientUUID, []v1.Report{
+		{
+			UpdatedAt: now.Add(-45 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 540, TotalDown: 760},
+		},
+		{
+			UpdatedAt: now.Add(-25 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 10, TotalDown: 20},
+		},
+		{
+			UpdatedAt: now.Add(-5 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 25, TotalDown: 35},
+		},
+	}, cache.DefaultExpiration)
+
+	require.NoError(t, saveClientReportToDB(db, now))
+
+	var saved models.Record
+	require.NoError(t, db.Where("client = ? AND time = ?", clientUUID, models.FromTime(now)).First(&saved).Error)
+	assert.Equal(t, int64(25), saved.NetTotalUp)
+	assert.Equal(t, int64(35), saved.NetTotalDown)
+	assert.Equal(t, int64(65), saved.TrafficUp)
+	assert.Equal(t, int64(95), saved.TrafficDown)
+}
+
+func TestSaveClientReportToDBDoesNotRecountRetainedCachePoints(t *testing.T) {
+	resetReportCache(t)
+	db := openReportCacheTestDB(t)
+
+	clientUUID := "client-retained-cache-point"
+	firstFlush := time.Date(2026, 6, 13, 12, 0, 30, 0, time.UTC)
+	secondFlush := firstFlush.Add(30 * time.Second)
+	require.NoError(t, db.Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(firstFlush.Add(-2 * time.Minute)),
+		NetTotalUp:   100,
+		NetTotalDown: 200,
+	}).Error)
+
+	Records.Set(clientUUID, []v1.Report{{
+		UpdatedAt: firstFlush.Add(-10 * time.Second),
+		Network:   v1.NetworkReport{TotalUp: 175, TotalDown: 320},
+	}}, cache.DefaultExpiration)
+
+	require.NoError(t, saveClientReportToDB(db, firstFlush))
+
+	reports, ok := Records.Get(clientUUID)
+	require.True(t, ok)
+	retained := reports.([]v1.Report)
+	retained = append(retained, v1.Report{
+		UpdatedAt: secondFlush.Add(-5 * time.Second),
+		Network:   v1.NetworkReport{TotalUp: 190, TotalDown: 360},
+	})
+	Records.Set(clientUUID, retained, cache.DefaultExpiration)
+
+	require.NoError(t, saveClientReportToDB(db, secondFlush))
+
+	var saved []models.Record
+	require.NoError(t, db.Where("client = ?", clientUUID).Order("time ASC").Find(&saved).Error)
+	require.Len(t, saved, 3)
+	assert.Equal(t, int64(75), saved[1].TrafficUp)
+	assert.Equal(t, int64(120), saved[1].TrafficDown)
+	assert.Equal(t, int64(15), saved[2].TrafficUp)
+	assert.Equal(t, int64(40), saved[2].TrafficDown)
+}
+
+func TestSaveClientReportToDBSkipsInvalidCachedReports(t *testing.T) {
+	resetReportCache(t)
+	db := openReportCacheTestDB(t)
+
+	clientUUID := "client-invalid-report"
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(now.Add(-2 * time.Minute)),
+		NetTotalUp:   100,
+		NetTotalDown: 200,
+	}).Error)
+
+	Records.Set(clientUUID, []v1.Report{
+		{
+			UpdatedAt: now.Add(-30 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: -1, TotalDown: 260},
+		},
+		{
+			UpdatedAt: now.Add(-10 * time.Second),
+			Network:   v1.NetworkReport{TotalUp: 175, TotalDown: 320},
+		},
+	}, cache.DefaultExpiration)
+
+	require.NoError(t, saveClientReportToDB(db, now))
+
+	var saved models.Record
+	require.NoError(t, db.Where("client = ? AND time = ?", clientUUID, models.FromTime(now)).First(&saved).Error)
+	assert.Equal(t, int64(175), saved.NetTotalUp)
+	assert.Equal(t, int64(320), saved.NetTotalDown)
+	assert.Equal(t, int64(75), saved.TrafficUp)
+	assert.Equal(t, int64(120), saved.TrafficDown)
+}
+
+func TestSaveClientReportToDBIgnoresSameTimeRowsWhenComputingDelta(t *testing.T) {
+	resetReportCache(t)
+	db := openReportCacheTestDB(t)
+
+	clientUUID := "client-same-time"
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(now.Add(-time.Minute)),
+		NetTotalUp:   100,
+		NetTotalDown: 200,
+	}).Error)
+	require.NoError(t, db.Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(now),
+		NetTotalUp:   999,
+		NetTotalDown: 999,
+	}).Error)
+
+	records := []models.Record{{
+		Client:       clientUUID,
+		Time:         models.FromTime(now),
+		NetTotalUp:   175,
+		NetTotalDown: 320,
+	}}
+	require.NoError(t, fillTrafficDeltas(db, records, nil))
+
+	assert.Equal(t, int64(75), records[0].TrafficUp)
+	assert.Equal(t, int64(120), records[0].TrafficDown)
+}
+
+func TestSaveClientReportToDBUsesLatestLongTermRecordWhenNewer(t *testing.T) {
+	resetReportCache(t)
+	db := openReportCacheTestDB(t)
+
+	clientUUID := "client-long-term-previous"
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(now.Add(-10 * time.Minute)),
+		NetTotalUp:   100,
+		NetTotalDown: 200,
+	}).Error)
+	require.NoError(t, db.Table("records_long_term").Create(&models.Record{
+		Client:       clientUUID,
+		Time:         models.FromTime(now.Add(-2 * time.Minute)),
+		NetTotalUp:   150,
+		NetTotalDown: 260,
+	}).Error)
+
+	records := []models.Record{{
+		Client:       clientUUID,
+		Time:         models.FromTime(now),
+		NetTotalUp:   175,
+		NetTotalDown: 320,
+	}}
+	require.NoError(t, fillTrafficDeltas(db, records, nil))
+
+	assert.Equal(t, int64(25), records[0].TrafficUp)
+	assert.Equal(t, int64(60), records[0].TrafficDown)
+}


### PR DESCRIPTION
## 变更说明 [4124d7c 更新](https://github.com/komari-monitor/komari/commit/4124d7c590e0b839c3e21d80c4fe61bf2953b82a)

本 PR 修复定时流量报告统计不准确的问题，尤其是部分用户首次收到每日/每周/每月流量报告时，报告内容显示为 `昨日流量 0 B` 的情况。

根因是 Agent 上报的是累计上传/下载水位，但缓存上报路径在按分钟聚合写入 `records` 时没有持久化对应的 `traffic_up` / `traffic_down` 增量。流量报告按持久化增量汇总时，就会得到 0。

本 PR 将流量统计逻辑统一为：服务端在落库阶段根据相邻累计水位计算增量，流量报告阶段只汇总指定周期内已经持久化的增量。同时，为已受影响的历史数据提供尽力修复和回退计算能力。

## 修复内容

- 统一缓存上报写入流程，为缓存中的 Agent 报告补充服务端时间戳，并通过共享追加逻辑写入缓存。
- 在缓存报告按分钟落库时，根据相邻 `net_total_up` / `net_total_down` 水位计算并保存 `traffic_up` / `traffic_down`。
- 调整 `AverageReport` 的流量水位保存逻辑，聚合记录保存最新累计上传/下载水位，而不是累计水位的平均值。
- 支持同一分钟内多条缓存报告的精确增量累加，并处理 Agent 重启或计数器重置导致的累计水位回退。
- 在 1 分钟记录压缩为 15 分钟长期记录时，保留已计算的精确流量增量，并使用该时间桶内最新累计水位作为长期记录的水位。
- 对已有历史数据中 `traffic_up` / `traffic_down` 为 0 的记录，尽力使用相邻累计水位回推增量，降低已受影响部署的后续统计误差。
- 流量报告查询同时读取短期 `records` 和长期 `records_long_term`，并处理两张表在重叠时间窗口内的去重，避免重复统计。
- 对无效缓存上报数据增加校验，避免异常数据进入聚合结果。
- 更新 Nezha 兼容上报路径和普通上报路径，确保运行时最新状态使用服务端保存后的报告时间戳。
- 增加单元测试，覆盖缓存落库增量计算、最新累计水位保存、计数器重置、历史零增量回退、长期记录压缩、短期/长期记录重叠去重等场景。

---

## 流量报告功能开发说明文档

下面总结的是流量报告功能的代码逻辑流程:

流量报告功能的核心逻辑是：Agent 上报累计流量水位，服务端把相邻水位之间的差值计算成实际使用量，然后日报、周报、月报只汇总指定时间段内已经落库的流量增量。

1. **Agent 上报累计流量水位**

   Agent 不直接上报“这一分钟用了多少流量”，而是持续上报累计值，例如 `total_up` 和 `total_down`。服务端收到报告后，会使用服务端时间写入 `UpdatedAt`，并先放入内存缓存中，同时更新节点的实时状态。

2. **服务端每分钟将缓存报告聚合成 1 分钟记录**

   服务端每分钟把缓存中的多条 Agent 报告聚合为一条 `records` 记录。CPU、内存、负载等普通指标仍按原有规则聚合；流量字段则分成两类保存：

   - `traffic_up` / `traffic_down`：这一条记录对应时间段内实际产生的上传/下载流量。
   - `net_total_up` / `net_total_down`：这一条记录结束时 Agent 上报的累计流量水位。

   计算增量时，服务端会拿当前水位和上一条已知水位比较。如果当前水位大于等于上一水位，就使用差值；如果当前水位小于上一水位，说明 Agent 可能重启或计数器重置，此时把当前水位视为重置后的新增流量。

3. **旧的 1 分钟记录会被压缩成 15 分钟长期记录**

   `records` 中的短期记录不会永久保留。压缩任务运行时，会以 `当前时间 - 4 小时` 再向下对齐到 15 分钟边界作为压缩截止点。早于该截止点的 1 分钟记录会被按客户端和 15 分钟时间桶聚合，写入 `records_long_term`。

   压缩后的长期记录仍然保留两类流量信息：

   - `traffic_up` / `traffic_down`：该 15 分钟桶内所有 1 分钟增量的总和。
   - `net_total_up` / `net_total_down`：该 15 分钟桶内最后一个水位，用作后续计算的持久化基线。

   为了避免查询时短期表和长期表之间出现空洞，原始 1 分钟记录不会在压缩后立刻全部删除。当前逻辑会保留约 1 小时重叠窗口，实际删除的是更早的原始记录。

4. **日报、周报、月报按时间段汇总流量增量**

   定时报告任务在每天、每周、每月的 0 点触发。服务端会查询启用了对应报告类型的客户端，然后按报告周期确定统计范围：

   - 日报：昨天 0 点到昨天结束。
   - 周报：上周一到上周日。
   - 月报：上个月第一天到最后一天。

   查询时会同时读取 `records` 和 `records_long_term`。如果同一个 15 分钟时间桶在短期表和长期表中都有数据，逻辑会避免重复计算。正常情况下，报告只需要累加 `traffic_up` / `traffic_down`。对于已经受影响的旧部署，如果历史记录中的 `traffic_up` / `traffic_down` 是 0，但仍保留了累计水位，当前补丁会尽量用相邻水位重新推算增量。

5. **最终按客户端流量类型生成报告数值**

   每个客户端可以配置不同的流量统计类型。服务端在得到上传和下载增量后，会根据配置计算最终显示值：

   - `up`：只看上传。
   - `down`：只看下载。
   - `sum`：上传加下载。
   - `min`：上传和下载中较小值。
   - `max`：上传和下载中较大值。

   最终报告消息会把每个启用报告的客户端按行输出，例如“昨日流量”“上周流量”或“上个月流量”。