### PR TITLE
fix: preserve node order in common:getNodes RPC

### DIFF
--- a/web/api/public/mjpeg.go
+++ b/web/api/public/mjpeg.go
@@ -970,7 +970,17 @@ func fetchNodeData(ctx context.Context) ([]NodeInfo, map[string]NodeStatus, erro
 		return nodes, statuses, fmt.Errorf("%v", nodesResp.Error.Message)
 	}
 	if nodesResp != nil && nodesResp.Result != nil {
-		if nodesMap, ok := nodesResp.Result.(map[string]interface{}); ok {
+		if nodesList, ok := nodesResp.Result.([]models.Client); ok {
+			for _, client := range nodesList {
+				nodes = append(nodes, nodeInfoFromClient(client))
+			}
+		} else if nodesList, ok := nodesResp.Result.([]interface{}); ok {
+			for _, v := range nodesList {
+				if nodeData, ok := v.(map[string]interface{}); ok {
+					nodes = append(nodes, parseNodeInfo(nodeData))
+				}
+			}
+		} else if nodesMap, ok := nodesResp.Result.(map[string]interface{}); ok {
 			for _, v := range nodesMap {
 				if nodeData, ok := v.(map[string]interface{}); ok {
 					node := parseNodeInfo(nodeData)
@@ -979,23 +989,7 @@ func fetchNodeData(ctx context.Context) ([]NodeInfo, map[string]NodeStatus, erro
 			}
 		} else if nodesMap, ok := nodesResp.Result.(map[string]models.Client); ok {
 			for _, client := range nodesMap {
-				nodes = append(nodes, NodeInfo{
-					UUID:           client.UUID,
-					Name:           client.Name,
-					IPv4:           client.IPv4,
-					IPv6:           client.IPv6,
-					Region:         client.Region,
-					Virtualization: client.Virtualization,
-					Price:          client.Price,
-					BillingCycle:   client.BillingCycle,
-					Currency:       client.Currency,
-					ExpiredAt:      client.ExpiredAt.ToTime(),
-					AutoRenewal:    client.AutoRenewal,
-					Hidden:         client.Hidden,
-					Weight:         client.Weight,
-					MemTotal:       client.MemTotal,
-					DiskTotal:      client.DiskTotal,
-				})
+				nodes = append(nodes, nodeInfoFromClient(client))
 			}
 		}
 	}
@@ -1063,6 +1057,26 @@ func fetchNodeData(ctx context.Context) ([]NodeInfo, map[string]NodeStatus, erro
 		}
 	}
 	return nodes, statuses, nil
+}
+
+func nodeInfoFromClient(client models.Client) NodeInfo {
+	return NodeInfo{
+		UUID:           client.UUID,
+		Name:           client.Name,
+		IPv4:           client.IPv4,
+		IPv6:           client.IPv6,
+		Region:         client.Region,
+		Virtualization: client.Virtualization,
+		Price:          client.Price,
+		BillingCycle:   client.BillingCycle,
+		Currency:       client.Currency,
+		ExpiredAt:      client.ExpiredAt.ToTime(),
+		AutoRenewal:    client.AutoRenewal,
+		Hidden:         client.Hidden,
+		Weight:         client.Weight,
+		MemTotal:       client.MemTotal,
+		DiskTotal:      client.DiskTotal,
+	}
 }
 
 func parseNodeInfo(data map[string]interface{}) NodeInfo {

--- a/web/rpc/jsonrpc/common.go
+++ b/web/rpc/jsonrpc/common.go
@@ -180,7 +180,7 @@ func init() {
 					Type:        "string",
 				},
 			},
-			Returns: "Client | { [uuid]: Client }",
+			Returns: "Client | Client[]",
 		},
 	)
 	RegisterWithGroupAndMeta("getNodesLatestStatus", "common",
@@ -262,11 +262,7 @@ func getNodes(ctx context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpcEr
 		return nil, rpc.MakeError(rpc.InvalidParams, "Node not found", params.UUID)
 	}
 
-	nodesMap := make(map[string]models.Client, len(cinfo))
-	for _, node := range cinfo {
-		nodesMap[node.UUID] = node
-	}
-	return nodesMap, nil
+	return cinfo, nil
 }
 
 func getPublicInfo(_ context.Context, _ *rpc.JsonRpcRequest) (any, *rpc.JsonRpcError) {


### PR DESCRIPTION
## Summary

Fix `common:getNodes` under `/api/rpc2` so the full node list preserves the same default backend order as `/api/nodes`.

## Problem

The public REST endpoint returns nodes in the expected order:

- `GET /api/nodes`

However, the JSON-RPC endpoint previously returned all nodes as an object keyed by UUID:

- `POST /api/rpc2`
- method: `common:getNodes`

Because JSON object key order should not be used as a stable ordering contract, clients could render nodes in a different order from the backend/default node order.

Online verification site:

- https://komari.yuanhhs.online/

## Root Cause

`clients.GetAllClientBasicInfo()` already returns an ordered `[]models.Client`, and `/api/nodes` keeps that array order.

`common:getNodes` converted that ordered slice into:

```go
map[string]models.Client
```

That conversion discarded the ordering guarantee for the full node response.

## Fix

- Return the filtered `[]models.Client` directly from `common:getNodes` when `uuid` is not specified.
- Keep the existing single-node behavior unchanged when `uuid` is specified.
- Update RPC metadata from `Client | { [uuid]: Client }` to `Client | Client[]`.
- Update the internal MJPEG node parser to handle the new array response.
- Keep MJPEG fallback support for the previous map-shaped response.

## Verification

Compared these two live responses from the online deployment:

- `GET https://komari.yuanhhs.online/api/nodes`
- `POST https://komari.yuanhhs.online/api/rpc2` with `common:getNodes`

Result:

```text
same_order = true
nodes_count = 13
rpc_count = 13
```

Observed order from both endpoints:

```text
Racknerd | Lowsla NAT | AliYuan | 42 NAT | Litevm NAT | Litevm NAT | CheaPhost NAT | Rabisu | 42 | Tencentyun | Digtalocean | rn | Digtalocean
```

## Tests

```bash
go test ./web/rpc/jsonrpc
```

Passed.

`go test ./...` could not complete in the local Windows environment because the current Go test environment is built with `CGO_ENABLED=0`, while several sqlite/go-sqlite3 tests require CGO. The source checkout also does not contain the embedded `web/public/defaultTheme` files required by some packages. These failures are unrelated to this change.