### PR TITLE
fix(rpc): 在 RPC 边界强制对敏感操作进行双因素认证（2FA）

### DIFF
--- a/pkg/rpc/sensitive.go
+++ b/pkg/rpc/sensitive.go
@@ -1,0 +1,28 @@
+package rpc
+
+// sensitive.go
+// 敏感操作登记表。被标记的方法（如 admin:exec）在通过角色鉴权后，仍需额外的
+// 敏感操作二次验证（sensitive 2FA）。登记与传输无关，由 RPC 边界统一判定，
+// 确保所有调用入口行为一致。
+
+import "sync"
+
+var (
+	muSensitive      sync.RWMutex
+	sensitiveMethods = map[string]bool{}
+)
+
+// MarkSensitive 标记某方法为敏感操作。method 为完整方法名（如 "admin:exec"）。
+// 重复标记是幂等的。供方法注册处声明。
+func MarkSensitive(method string) {
+	muSensitive.Lock()
+	defer muSensitive.Unlock()
+	sensitiveMethods[method] = true
+}
+
+// IsSensitive 判断方法是否被标记为敏感操作。
+func IsSensitive(method string) bool {
+	muSensitive.RLock()
+	defer muSensitive.RUnlock()
+	return sensitiveMethods[method]
+}

--- a/web/api/AuthSensitive.go
+++ b/web/api/AuthSensitive.go
@@ -17,6 +17,8 @@ func RequireSensitive2FA() gin.HandlerFunc {
 			c.Abort()
 			return
 		}
+		// 标记本请求已通过敏感操作校验，避免下游（RPC 边界）在 body 被消费后重复校验。
+		c.Set("sensitive_2fa_verified", true)
 		c.Next()
 	}
 }

--- a/web/rpc/jsonrpc/admin.system.go
+++ b/web/rpc/jsonrpc/admin.system.go
@@ -38,6 +38,9 @@ func init() {
 	reg("exec", adminExec, "Execute a command on clients")
 	reg("testSendMessage", adminTestSendMessage, "Send a test notification")
 	reg("testGeoip", adminTestGeoip, "Test GeoIP lookup")
+
+	// 远程命令执行属敏感操作：除 admin 角色外，还需通过敏感操作二次验证。
+	rpc.MarkSensitive("admin:exec")
 }
 
 func adminGetLogs(_ context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpcError) {

--- a/web/rpc/jsonrpc/transport.go
+++ b/web/rpc/jsonrpc/transport.go
@@ -61,7 +61,25 @@ func CallFromGin(c *gin.Context, method string, params any) *rpc.JsonRpcResponse
 		}
 	}
 	req := &rpc.JsonRpcRequest{Version: rpc.RPC_VERSION, Method: method, Params: params}
-	return Dispatch(c.Request.Context(), meta, req)
+	return dispatchWithSensitive(c.Request.Context(), c, meta, req)
+}
+
+// dispatchWithSensitive 在统一分发前对敏感方法补充二次验证，使各调用入口行为一致。
+// 对已通过命名空间权限校验的敏感方法，要求调用方满足敏感操作 2FA（沿用
+// api.VerifySensitive2FA 语义：API Key 放行、未配置 2FA 的账号沿用既有行为），
+// 再交由 Dispatch 执行；Dispatch 仍为权威鉴权点。
+//
+// 若请求已被 RequireSensitive2FA 中间件校验过（sensitive_2fa_verified），则跳过，
+// 避免在 body 被解析消费后重复读取校验。经 /api/rpc2 调用时无该中间件，2FA 码由
+// X-2FA-Code 请求头（或 query）传入。
+func dispatchWithSensitive(ctx context.Context, c *gin.Context, meta *rpc.ContextMeta, req *rpc.JsonRpcRequest) *rpc.JsonRpcResponse {
+	if c != nil && meta != nil && !c.GetBool("sensitive_2fa_verified") &&
+		rpc.IsSensitive(req.Method) && rpc.CheckPermission(meta.Permission, req.Method) {
+		if err := api.VerifySensitive2FA(c); err != nil {
+			return rpc.ErrorResponse(req.ID, rpc.PermissionDenied, err.Error(), nil)
+		}
+	}
+	return Dispatch(ctx, meta, req)
 }
 
 func serveWebSocket(c *gin.Context) {
@@ -92,7 +110,7 @@ func serveWebSocket(c *gin.Context) {
 			continue
 		}
 		// 同步写：SafeConn 内部有锁，串行写避免响应乱序与并发竞态。
-		conn.WriteJSON(Dispatch(context.Background(), meta, &req))
+		conn.WriteJSON(dispatchWithSensitive(context.Background(), c, meta, &req))
 	}
 }
 
@@ -112,7 +130,7 @@ func servePost(c *gin.Context) {
 
 	responses := make([]*rpc.JsonRpcResponse, 0, len(requests))
 	for _, rreq := range requests {
-		responses = append(responses, Dispatch(c.Request.Context(), meta, rreq))
+		responses = append(responses, dispatchWithSensitive(c.Request.Context(), c, meta, rreq))
 	}
 	// 单条直接对象，批量数组（符合 JSON-RPC 2.0）。
 	if len(responses) == 1 {


### PR DESCRIPTION
## 问题
2FA 二次验证函数（`RequireSensitive2FA`）此前**只**作为 gin 中间件挂在 REST 路由`POST /api/admin/task/exec` 上：

```go
// web/router/router.go
task.POST("/exec", api.RequireSensitive2FA(), jsonRpc.Bind("admin:exec"))
```

但同一个方法 `admin:exec`（向所有 agent 下发命令）还能经通用入口 `/api/rpc2`（`POST` 与 `WebSocket`）调用。该入口注册在公开路由里，只有全局中间件，**不经过** `RequireSensitive2FA`：

```go
// web/router/router.go —— 公开路由，无 RequireRole / 无 RequireSensitive2FA
r.GET("/api/rpc2", jsonRpc.OnRpcRequest)
r.POST("/api/rpc2", jsonRpc.OnRpcRequest)
```

而统一分发器 `Dispatch` 只做"私有站点检查 + 命名空间角色 ACL"，**没有**敏感操作二次验证；`adminExec` 方法体内部也没有任何 2FA 校验：

```go
// web/rpc/jsonrpc/dispatch.go（节选）
if !rpc.CheckPermission(group, req.Method) {   // 只校验 admin/client/guest 角色
    return PermissionDenied
}
return rpc.CallWithContext(...)                 // 直接执行，无敏感操作 2FA
```

示例：
```bash
curl -s -b "$COOKIES" -X POST "$URL/api/rpc2" \
  -H 'Content-Type: application/json' \
  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"admin:exec\",\"params\":{\"command\":\"id\",\"clients\":[\"$CLIENT_ID\"]}}"
```

**结果：** 任何**已认证的 admin 会话**（角色校验可过）只要走 `/api/rpc2` 调 `admin:exec`，即可在**不提供任何 TOTP 码**的情况下对所有在线 agent 远程执行命令，在 admin session 被窃取后尤其危险

## 修复

把校验从**路由中间件**下沉到 **JSON-RPC 边界**：

- `pkg/rpc`：新增**传输无关的敏感方法登记表**（`MarkSensitive` / `IsSensitive`）。
- `web/rpc/jsonrpc`：新增 `dispatchWithSensitive`，并让 REST 路由桥（`CallFromGin`）、rpc2 `POST`（`servePost`）、rpc2 `WebSocket`（`serveWebSocket`）三条入口都经过它；对**已通过命名空间 ACL 的敏感方法**，在分发前统一调用`api.VerifySensitive2FA` 强制二次验证。
- 标记 `admin:exec` 为敏感操作。