### PR TITLE
fix: 修复 records_long_term / gpu_records_long_term 长期记录重复写入

### DIFF
--- a/database/records/records.go
+++ b/database/records/records.go
@@ -335,8 +335,11 @@ func migrateOldRecordsAt(db *gorm.DB, now time.Time) error {
 			// 取高位
 			high_percentile := 0.7
 			// 检查 records_long_term 表中是否已存在相同的记录
+			// 注意：time 列经 models.LocalTime.Value() 以本地时区/自定义格式写入，
+			// WHERE 比较必须同样包成 models.FromTime，否则裸 time.Time 序列化不一致，永远匹配不到 -> 重复插入。
+			slotTime := models.FromTime(timeSlot)
 			var existingCount int64
-			if err := tx.Table("records_long_term").Where("client = ? AND time = ?", clientUUID, timeSlot).Count(&existingCount).Error; err != nil {
+			if err := tx.Table("records_long_term").Where("client = ? AND time = ?", clientUUID, slotTime).Count(&existingCount).Error; err != nil {
 				return err
 			}
 
@@ -367,7 +370,7 @@ func migrateOldRecordsAt(db *gorm.DB, now time.Time) error {
 
 			// 如果记录已存在则更新，否则创建新记录
 			if existingCount > 0 {
-				if err := tx.Table("records_long_term").Where("client = ? AND time = ?", clientUUID, timeSlot).Updates(&newRec).Error; err != nil {
+				if err := tx.Table("records_long_term").Where("client = ? AND time = ?", clientUUID, slotTime).Updates(&newRec).Error; err != nil {
 					return err
 				}
 			} else {
@@ -567,10 +570,11 @@ func migrateGPURecords(db *gorm.DB) error {
 
 	return db.Transaction(func(tx *gorm.DB) error {
 		for key, data := range groupedGPUs {
-			// 检查是否已存在记录
+			// 检查是否已存在记录（time 须包成 models.FromTime，理由同 migrateOldRecordsAt）
+			slotTime := models.FromTime(key.TimeSlot)
 			var existingCount int64
 			if err := tx.Table("gpu_records_long_term").Where("client = ? AND device_index = ? AND time = ?",
-				key.Client, key.DeviceIndex, key.TimeSlot).Count(&existingCount).Error; err != nil {
+				key.Client, key.DeviceIndex, slotTime).Count(&existingCount).Error; err != nil {
 				return err
 			}
 
@@ -588,7 +592,7 @@ func migrateGPURecords(db *gorm.DB) error {
 			if existingCount > 0 {
 				// 更新已存在记录
 				if err := tx.Table("gpu_records_long_term").Where("client = ? AND device_index = ? AND time = ?",
-					key.Client, key.DeviceIndex, key.TimeSlot).Updates(&compressedGPU).Error; err != nil {
+					key.Client, key.DeviceIndex, slotTime).Updates(&compressedGPU).Error; err != nil {
 					return err
 				}
 			} else {

--- a/database/records/records_test.go
+++ b/database/records/records_test.go
@@ -319,3 +319,36 @@ func TestCompactRecordOnlyMigratesCompleteFifteenMinuteBuckets(t *testing.T) {
 	assert.NoError(t, db.Table("records").Where("time = ?", partialSlot.Time).Count(&rawCount).Error)
 	assert.Equal(t, int64(1), rawCount)
 }
+
+// TestCompactRecordNoDuplicateOnRepeatedRuns 回归测试：重叠带内的记录会被多轮压缩
+// 重复处理，去重检查必须命中已存在的 long-term 行并 Update，而非 Create 出重复。
+// 修复前 WHERE 用裸 time.Time 与 LocalTime.Value() 的存储格式不匹配，第二轮会插出重复行。
+func TestCompactRecordNoDuplicateOnRepeatedRuns(t *testing.T) {
+	loc := models.GetAppLocation()
+	now := time.Date(2026, 6, 7, 12, 7, 0, 0, loc)
+	cutoff := compactRecordCutoff(now)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	assert.NoError(t, err)
+	assert.NoError(t, db.AutoMigrate(&models.Record{}))
+	assert.NoError(t, db.Table("records_long_term").AutoMigrate(&models.Record{}))
+
+	// 位于重叠带 [cutoff-1h, cutoff)：每轮都 <cutoff 会被压缩，但 >cutoff-1h 不会被删除。
+	slotRec := models.Record{Client: uuid, Time: models.FromTime(cutoff.Add(-30 * time.Minute)), Cpu: 42}
+	assert.NoError(t, db.Create(&slotRec).Error)
+
+	// 连续压缩三轮，模拟约 1 小时内多次定时压缩同一槽位。
+	for i := 0; i < 3; i++ {
+		assert.NoError(t, migrateOldRecordsAt(db, now))
+	}
+
+	slot := slotRec.Time.ToTime().Truncate(15 * time.Minute)
+	var slotCount int64
+	assert.NoError(t, db.Table("records_long_term").
+		Where("client = ? AND time = ?", uuid, models.FromTime(slot)).
+		Count(&slotCount).Error)
+	assert.Equal(t, int64(1), slotCount, "重复压缩不应在 long-term 表产生重复行")
+
+	var totalLong int64
+	assert.NoError(t, db.Table("records_long_term").Count(&totalLong).Error)
+	assert.Equal(t, int64(1), totalLong)
+}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -133,6 +133,145 @@ func Run(ctx Context) error {
 		}
 	}
 
+	if err := dedupeLongTermRecords(db); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// dedupeLongTermRecords 清理长期表中的存量重复行。
+//
+// 历史上压缩去重的 WHERE 子句使用了裸 time.Time，与 LocalTime.Value()
+// 写入的本地时区/自定义格式字符串无法匹配，导致每轮压缩对同一 (client,time)
+// 反复 Create，产生 ×N 重复（已在 database/records 修复）。此迁移按
+// (client,time) / (client,device_index,time) 唯一性清理历史重复，保留一条。
+//
+// 设计为幂等：先用 GROUP BY ... HAVING COUNT(*)>1 探测，无重复则直接跳过；
+// 表不存在（全新安装，AutoMigrate 尚未建表）时同样跳过。
+func dedupeLongTermRecords(db *gorm.DB) error {
+	if db.Migrator().HasTable("records_long_term") {
+		var dupGroups int64
+		if err := db.Raw("SELECT COUNT(*) FROM (SELECT client, time FROM records_long_term GROUP BY client, time HAVING COUNT(*) > 1) AS d").Scan(&dupGroups).Error; err != nil {
+			return fmt.Errorf("count duplicate long-term records: %w", err)
+		}
+		if dupGroups > 0 {
+			log.Printf("[dedup] records_long_term has %d duplicated (client,time) groups, cleaning up...", dupGroups)
+			if err := rebuildDedupedRecords(db); err != nil {
+				return err
+			}
+			log.Printf("[dedup] records_long_term cleanup done")
+		}
+	}
+
+	if db.Migrator().HasTable("gpu_records_long_term") {
+		var dupGroups int64
+		if err := db.Raw("SELECT COUNT(*) FROM (SELECT client, device_index, time FROM gpu_records_long_term GROUP BY client, device_index, time HAVING COUNT(*) > 1) AS d").Scan(&dupGroups).Error; err != nil {
+			return fmt.Errorf("count duplicate long-term GPU records: %w", err)
+		}
+		if dupGroups > 0 {
+			log.Printf("[dedup] gpu_records_long_term has %d duplicated (client,device_index,time) groups, cleaning up...", dupGroups)
+			if err := rebuildDedupedGPURecords(db); err != nil {
+				return err
+			}
+			log.Printf("[dedup] gpu_records_long_term cleanup done")
+		}
+	}
+
+	return nil
+}
+
+// rebuildDedupedRecords 逐客户端去重 records_long_term。
+// 两个长期表均无主键，故不能用 rowid/id 做方言相关删除；改为读出该客户端
+// 全部行 -> 内存按 time 去重 -> 事务内删除该客户端旧行并批量重插，跨 SQLite/MySQL 通用。
+func rebuildDedupedRecords(db *gorm.DB) error {
+	var clientList []string
+	if err := db.Table("records_long_term").Distinct("client").Pluck("client", &clientList).Error; err != nil {
+		return fmt.Errorf("list clients for record dedup: %w", err)
+	}
+
+	for _, clientUUID := range clientList {
+		var rows []models.Record
+		if err := db.Table("records_long_term").Where("client = ?", clientUUID).Order("time ASC").Find(&rows).Error; err != nil {
+			return fmt.Errorf("load long-term records for %s: %w", clientUUID, err)
+		}
+
+		seen := make(map[string]struct{}, len(rows))
+		deduped := make([]models.Record, 0, len(rows))
+		for _, r := range rows {
+			key := r.Time.ToTime().UTC().Format(time.RFC3339Nano)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			deduped = append(deduped, r)
+		}
+
+		if len(deduped) == len(rows) {
+			continue // 该客户端无重复
+		}
+
+		if err := db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Table("records_long_term").Where("client = ?", clientUUID).Delete(&models.Record{}).Error; err != nil {
+				return err
+			}
+			if len(deduped) > 0 {
+				if err := tx.Table("records_long_term").CreateInBatches(&deduped, 500).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("rewrite deduped long-term records for %s: %w", clientUUID, err)
+		}
+	}
+
+	return nil
+}
+
+// rebuildDedupedGPURecords 逐客户端去重 gpu_records_long_term，键为 (device_index,time)。
+func rebuildDedupedGPURecords(db *gorm.DB) error {
+	var clientList []string
+	if err := db.Table("gpu_records_long_term").Distinct("client").Pluck("client", &clientList).Error; err != nil {
+		return fmt.Errorf("list clients for GPU record dedup: %w", err)
+	}
+
+	for _, clientUUID := range clientList {
+		var rows []models.GPURecord
+		if err := db.Table("gpu_records_long_term").Where("client = ?", clientUUID).Order("time ASC").Find(&rows).Error; err != nil {
+			return fmt.Errorf("load long-term GPU records for %s: %w", clientUUID, err)
+		}
+
+		seen := make(map[string]struct{}, len(rows))
+		deduped := make([]models.GPURecord, 0, len(rows))
+		for _, r := range rows {
+			key := fmt.Sprintf("%d|%s", r.DeviceIndex, r.Time.ToTime().UTC().Format(time.RFC3339Nano))
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			deduped = append(deduped, r)
+		}
+
+		if len(deduped) == len(rows) {
+			continue
+		}
+
+		if err := db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Table("gpu_records_long_term").Where("client = ?", clientUUID).Delete(&models.GPURecord{}).Error; err != nil {
+				return err
+			}
+			if len(deduped) > 0 {
+				if err := tx.Table("gpu_records_long_term").CreateInBatches(&deduped, 500).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("rewrite deduped long-term GPU records for %s: %w", clientUUID, err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# fix: 修复 records_long_term / gpu_records_long_term 长期记录重复写入

## 概述 / Summary

长期记录压缩任务的去重检查因时间字段序列化不一致而**始终失效**，导致每个 15 分钟时间槽在长期表中被重复写入约 3 份（取值完全相同）。本 PR 修复去重匹配逻辑，并新增一次性迁移清理存量重复数据。

- 影响范围：所有实例（作者实例 `ss.akz.moe` 与自建实例均复现）。
- 仅长期表 `records_long_term` / `gpu_records_long_term` 受影响，短期表 `records` 正常。

---

## 问题描述 / Problem

通过 `POST /api/rpc2`（方法 `common:getRecords`）拉取历史数据时，长期记录存在大量重复：

- 15 分钟对齐的时间戳（`:00/:15/:30/:45`）每条被存储约 **3 份**，取值完全相同。
- 几乎所有节点都受影响；最近 4 小时的短期数据正常。

### 复现 / Reproduction

```bash
curl -s -X POST 'https://<host>/api/rpc2' \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"common:getRecords",
       "params":{"type":"load","hours":24,"load_type":"cpu","maxCount":-1}}'
```

观测（某节点，48h–24h 前的纯长期表窗口）：

```
总记录 282 条，唯一时间戳仅 96 个
90 个时间戳出现 3 次，6 个出现 2 次
示例：2026-06-26T19:15:00Z 三次取值均为 15.021169
```

---

## 根因 / Root Cause

压缩任务 `migrateOldRecordsAt`（`database/records/records.go`）已有去重逻辑：写入前查重，存在则 `Updates`，否则 `Create`。但查重的 `WHERE time = ?` 传入的是**裸 `time.Time`（UTC）**：

```go
timeSlot, _ := time.Parse(time.RFC3339, ...)            // UTC, 裸 time.Time
tx.Table("records_long_term").
   Where("client = ? AND time = ?", clientUUID, timeSlot).Count(&existingCount)
```

而 `time` 列是自定义类型 `models.LocalTime`，落库格式由 `Value()` 决定（`database/models/UTCTime.go`）：

```go
func (t LocalTime) Value() (driver.Value, error) {
    return time.Time(t).In(GetAppLocation()).Format("2006-01-02 15:04:05.0000000"), nil
}
```

即存储为「**应用本地时区 + 无时区后缀 + 自定义格式**」的字符串（如 `2026-06-27 03:15:00.0000000`）。

两者**时区不同、格式不同** → `time = ?` 永远匹配不到已存在行 → `existingCount` 恒为 0 → 每轮都 `Create` → 重复插入。

### 为什么是 3 倍

压缩条件为 `time < cutoff`（`cutoff = now-4h`，截断到 15 分钟），删除条件为 `time < cutoff-1h`。因此 `[now-5h, now-4h]` 这 1 小时的记录在被删除前会被反复压缩；压缩任务约每 20 分钟一次，同一槽位在删除前被压缩约 3 次，去重失效即产生 ×3。

### 佐证

同文件 `getPreviousTrafficRecordBefore` 的时间比较是**正确**的，包了 `models.FromTime`：

```go
Where("client = ? AND time < ?", clientUUID, models.FromTime(queryBefore))  // ✅
```

压缩去重处漏掉了这层包装；GPU 压缩 `migrateGPURecords` 同样存在该问题。

---

## 改动 / Changes

### 1. `database/records/records.go` — 修复去重匹配

将压缩去重中 4 处 `WHERE time = ?` 的裸时间值统一包成 `models.FromTime(...)`，使其与落库格式一致，令查重命中已存在行（走 `Update` 而非 `Create`）：

| 函数 | 位置 |
|---|---|
| `migrateOldRecordsAt` | 查重 `Count` 的 `WHERE` |
| `migrateOldRecordsAt` | 更新 `Updates` 的 `WHERE` |
| `migrateGPURecords` | GPU 查重 `Count` 的 `WHERE` |
| `migrateGPURecords` | GPU 更新 `Updates` 的 `WHERE` |

```go
slotTime := models.FromTime(timeSlot)
tx.Table("records_long_term").
   Where("client = ? AND time = ?", clientUUID, slotTime).Count(&existingCount)
```

### 2. `pkg/migrations/migrations.go` — 清理存量重复

新增 `dedupeLongTermRecords` 并挂入 `Run()`，按唯一性清理历史重复，每组保留一条：

- `records_long_term`：按 `(client, time)`
- `gpu_records_long_term`：按 `(client, device_index, time)`

设计要点：

- **幂等**：先用 `GROUP BY ... HAVING COUNT(*) > 1` 探测，无重复 / 表不存在则跳过，可随每次启动安全执行。
- **可移植**：两表无主键（`Record` / `GPURecord` 无 `id`），不能用 `rowid`/`id` 做方言删除；改为**逐客户端重建**（读出 → 内存去重 → 事务内删旧行并批量重插），SQLite / MySQL 通用。

触发时打印日志：

```
[dedup] records_long_term has N duplicated (client,time) groups, cleaning up...
[dedup] records_long_term cleanup done
```

### 3. `database/records/records_test.go` — 回归测试

新增 `TestCompactRecordNoDuplicateOnRepeatedRuns`：在重叠带放入一条记录，连续压缩 3 轮，断言长期表最终只剩 1 行。

---

## 测试 / Testing

```bash
go build ./database/records ./pkg/migrations   # ✅
go vet   ./database/records ./pkg/migrations   # ✅
go test  ./database/records ./pkg/migrations   # ✅ all pass
```

- 新回归测试：**修复前 FAIL（复现重复）、修复后 PASS**。

---

## 影响 / Impact

- **新增重复**：部署后立即停止。
- **存量重复**：随带本修复的二进制重启时由迁移自动清理一次。
- **数据安全**：清理在事务内逐客户端进行，去重保留一条，原值不变（重复行为完全相同的副本）。
- **兼容性**：无 schema 变更，无 API 变更，向后兼容。

---

## Checklist

- [x] 修复根因（去重匹配）
- [x] 清理存量数据（幂等迁移）
- [x] 新增回归测试，覆盖该缺陷
- [x] `build` / `vet` / `test` 通过
- [x] 无破坏性变更（无 schema / API 改动）
