### PR TITLE
fix(telegram): 非 200 响应时返回 API 错误描述而非仅状态码

### DIFF
--- a/utils/messageSender/telegram/telegram.go
+++ b/utils/messageSender/telegram/telegram.go
@@ -60,16 +60,19 @@ func (t *TelegramSender) SendTextMessage(message, title string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("telegram API returned non-OK status: %d", resp.StatusCode)
-	}
-
 	var result struct {
 		Ok          bool   `json:"ok"`
 		Description string `json:"description"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return err
+		return fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if result.Description != "" {
+			return fmt.Errorf("telegram API error: %s", result.Description)
+		}
+		return fmt.Errorf("telegram API returned non-OK status: %d", resp.StatusCode)
 	}
 
 	if !result.Ok {


### PR DESCRIPTION
问题发现过程
---

生产环境中 komari 测试发送 Telegram 通知返回 500 错误，日志仅显示 `telegram API returned non-OK status: 400`，无法确定原因。

通过对比 curl 和 Go `http.PostForm` 的请求行为，确认两者均能正常到达 Telegram API。最终定位到通知模板中使用了未闭合 HTML 标签，Telegram 返回 400 及具体的 `description` 字段，但 `SendTextMessage` 丢弃了这段信息。

根因
---

`SendTextMessage` 先检查 `resp.StatusCode`，非 200 分支直接返回状态码，没有 decode `body` 中的 `description` 字段。

修改
---

将 JSON decode 移到 status 检查之前。非 200 时优先取 `description` 作为错误消息；
decode 失败或 `description` 为空时 fallback 到原状态码提示。

**修改前**：telegram API returned non-OK status: 400
**修改后**：telegram API error: Bad Request: can't parse entities: ...