### PR TITLE
fix(security): prevent path traversal in theme name (DeleteTheme/UpdateTheme/SetTheme)

### DIFF
--- a/web/api/admin/theme.go
+++ b/web/api/admin/theme.go
@@ -108,6 +108,12 @@ func DeleteTheme(c *gin.Context) {
 		return
 	}
 
+	// 校验主题短名称，防止路径穿越（如 ../）导致删除工作目录外的任意文件
+	if !isValidThemeShort(req.Short) {
+		api.RespondError(c, http.StatusBadRequest, "无效的主题名称")
+		return
+	}
+
 	themeDir := filepath.Join("./data/theme", req.Short)
 
 	// 检查主题是否存在
@@ -135,6 +141,11 @@ func SetTheme(c *gin.Context) {
 
 	// 如果不是default主题，检查主题是否存在
 	if themeName != "default" {
+		// 校验主题名称，防止路径穿越（如 ../）访问工作目录外的文件
+		if !isValidThemeShort(themeName) {
+			api.RespondError(c, http.StatusBadRequest, "无效的主题名称")
+			return
+		}
 		themeDir := filepath.Join("./data/theme", themeName)
 		themeConfigPath := filepath.Join(themeDir, "komari-theme.json")
 
@@ -472,6 +483,12 @@ func UpdateTheme(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		api.RespondError(c, http.StatusBadRequest, "参数错误: "+err.Error())
+		return
+	}
+
+	// 校验主题短名称，防止路径穿越（如 ../）访问工作目录外的文件
+	if !isValidThemeShort(req.Short) {
+		api.RespondError(c, http.StatusBadRequest, "无效的主题名称")
 		return
 	}
 

--- a/web/api/admin/theme_test.go
+++ b/web/api/admin/theme_test.go
@@ -1,0 +1,47 @@
+package admin
+
+import "testing"
+
+// TestIsValidThemeShort_PathTraversal 防止 DeleteTheme/UpdateTheme/SetTheme
+// 的路径穿越漏洞：req.Short 直接进入 filepath.Join("./data/theme", short)，
+// 若 short 含 "../" 会规范化到 ./data/theme 之外，配合 os.RemoveAll 可删除
+// 工作目录外任意目录。isValidThemeShort 必须拒绝所有此类 payload。
+func TestIsValidThemeShort_PathTraversal(t *testing.T) {
+	// 必须被拒绝：路径穿越 / 绝对路径 / 目录分隔符 / 空值 / default
+	deny := []string{
+		"",
+		"default",
+		"..",
+		"../",
+		"./",
+		"../../etc",
+		"../..",
+		"foo/../bar",
+		"/etc/passwd",
+		"foo/bar",
+		"foo\\bar",
+		"a b",
+		"a;b",
+		"a$(id)",
+	}
+	for _, in := range deny {
+		if isValidThemeShort(in) {
+			t.Errorf("isValidThemeShort(%q) = true, want false (路径穿越/非法字符未被拦截)", in)
+		}
+	}
+
+	// 必须被接受：仅字母数字下划线连字符
+	accept := []string{
+		"mytheme",
+		"my-theme",
+		"my_theme",
+		"theme123",
+		"ABC",
+		"a",
+	}
+	for _, in := range accept {
+		if !isValidThemeShort(in) {
+			t.Errorf("isValidThemeShort(%q) = false, want true (合法名称被误拒)", in)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a path traversal in theme management endpoints. The user-supplied theme `short` name was used directly in `filepath.Join("./data/theme", short)` before filesystem operations (`os.RemoveAll` / `os.Stat`), without any validation. `filepath.Join` normalizes the result, so a crafted value escapes the theme directory.

## Affected handlers (`web/api/admin/theme.go`)

All three require an authenticated admin (`RequireRole(RoleAdmin)`), but the impact is still serious once an admin session is held (e.g. via weak password V2, session hijack, or a compromised admin).

- `DeleteTheme` (`os.RemoveAll`) — **arbitrary directory deletion**
- `UpdateTheme` (`os.Stat` + read)
- `SetTheme` (`os.Stat`)

## PoC

`filepath.Join("./data/theme", "../../")` normalizes to `.` — the working directory itself:

```go
short := "../../etc"
themeDir := filepath.Join("./data/theme", short) // -> "etc", outside data/theme
os.RemoveAll(themeDir)                            // deletes outside the theme dir
```

A sandbox simulation confirmed `os.RemoveAll` deletes the victim directory with `err=nil`.

## Fix

Reuse the existing `isValidThemeShort` validator (allowlist of `[a-zA-Z0-9_-]`, already used correctly in `extractAndValidateTheme`) in all three handlers, before the path is constructed. No new dependencies.

## Testing

- Added `TestIsValidThemeShort_PathTraversal` covering traversal payloads (`../`, `../../etc`, `/etc/passwd`, `foo/bar`, `foo\bar`), empty, `default`, and valid names.
- `go build ./...`, `go vet`, and the new test pass.

```text
=== RUN   TestIsValidThemeShort_PathTraversal
--- PASS: TestIsValidThemeShort_PathTraversal (0.00s)
PASS
ok  	github.com/komari-monitor/komari/web/api/admin
```

## Notes

This is part of a broader security review. Related findings (weak password hashing, SSRF DNS rebinding, vulnerable dependencies) are tracked separately.