### PR TITLE
fix: harden visitor audit logging

### DIFF
--- a/database/models/log.go
+++ b/database/models/log.go
@@ -5,6 +5,6 @@ type Log struct {
 	IP      string    `json:"ip" gorm:"type:varchar(45);"` // IPv4 or IPv6
 	UUID    string    `json:"uuid" gorm:"type:varchar(36);"`
 	Message string    `json:"message" gorm:"type:text;not null"`
-	MsgType string    `json:"msg_type" gorm:"type:varchar(20);not null"`
-	Time    LocalTime `json:"time" gorm:"autoCreateTime;not null"`
+	MsgType string    `json:"msg_type" gorm:"type:varchar(20);not null;index:idx_logs_msg_type_time,priority:1"`
+	Time    LocalTime `json:"time" gorm:"autoCreateTime;not null;index:idx_logs_time;index:idx_logs_msg_type_time,priority:2"`
 }

--- a/database/utils.go
+++ b/database/utils.go
@@ -135,6 +135,7 @@ func GetPublicInfo() (map[string]interface{}, error) {
 		"ping_record_preserve_time": metricCfg.RetentionDays * 24, //兼容旧版本主题
 		"metric_retention_days":     metricCfg.RetentionDays,
 		"private_site":              cst.PrivateSite,
+		"visitor_audit_enabled":     cst.VisitorAuditEnabled,
 		"theme":                     cst.Theme,
 		"theme_settings":            tc_data,
 	}, nil

--- a/docs/visitor-audit-rpc.md
+++ b/docs/visitor-audit-rpc.md
@@ -10,6 +10,7 @@
 - 写入位置：现有审计日志表 `models.Log`
 - 管理端读取：复用现有 `admin:getLogs`
 - 日志类型：`msg_type = "visitor"`
+- 默认状态：关闭，需设置 `visitor_audit_enabled = true`
 
 该接口不会信任前端传入的 IP。来源 IP 和 User-Agent 由后端从请求上下文记录。
 
@@ -18,6 +19,17 @@
 `public:recordVisitorEvent` 属于 `public` 命名空间，访客可调用。
 
 私有站点模式下，该方法也在登录页白名单内，便于记录登录前/前台访问事件。
+
+这是有意保留的行为；总开关关闭时，白名单中的方法仍可调用，但不会写库。
+
+## 启用
+
+存量实例和新实例默认都不会开放匿名日志写入。管理员可通过
+`admin:editSettings` 将 `visitor_audit_enabled` 设为 `true`。公开设置
+`public:getPublicSettings` 也会返回这个字段，主题可据此决定是否上报。
+
+未启用时接口返回 `status = "disabled"`。启用后，每个来源 IP 使用内存令牌桶限流：
+平均每分钟 30 次，允许短时突发 10 次；超限时返回 `status = "rate_limited"`，不写库。
 
 ## 请求参数
 
@@ -48,12 +60,15 @@ event > action > operation
 
 ## 字段限制
 
+字符串字段按 Unicode 字符计数，`detail` 和最终 message 按序列化后的字节数计数。
+
 | 字段 | 最大长度 |
 | --- | ---: |
 | `event` | 64 |
 | `path` | 512 |
 | `route` | 128 |
 | `target` | 128 |
+| User-Agent | 512 |
 | `detail` JSON | 2048 |
 | 最终日志 message | 4096 |
 
@@ -102,7 +117,7 @@ curl -X POST http://localhost:25774/api/rpc2 \
   }'
 ```
 
-成功返回：
+写入成功返回：
 
 ```json
 {
@@ -113,6 +128,8 @@ curl -X POST http://localhost:25774/api/rpc2 \
   "id": 1
 }
 ```
+
+`disabled` 和 `rate_limited` 也属于正常响应，不会返回 JSON-RPC 错误；主题上报不应影响主流程。
 
 ## 请求示例：打开节点详情
 
@@ -261,17 +278,15 @@ admin:getLogs
   "method": "admin:getLogs",
   "params": {
     "limit": "100",
-    "page": "1"
+    "page": "1",
+    "msg_type": "visitor"
   },
   "id": 10
 }
 ```
 
-返回中的访客记录可通过以下条件筛选：
-
-```text
-msg_type === "visitor"
-```
+`msg_type` 为可选的精确匹配过滤参数。传入 `visitor` 后，计数和分页都会在 SQL 查询层过滤，
+无需先拉取所有日志再由前端筛选。
 
 ## 安全注意事项
 

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -16,6 +16,7 @@ type Settings struct {
 	AutoDiscoveryKey       string `json:"auto_discovery_key" default:""`                       // 自动发现密钥
 	ScriptDomain           string `json:"script_domain" default:""`                            // 自定义脚本域名
 	SendIpAddrToGuest      bool   `json:"send_ip_addr_to_guest" default:"false"`               // 是否向访客页面发送 IP 地址，默认 false
+	VisitorAuditEnabled    bool   `json:"visitor_audit_enabled" default:"false"`               // 是否允许公开访客事件写入审计日志，默认 false
 	EulaAccepted           bool   `json:"eula_accepted" default:"false"`
 	BaseScriptsURLKey      string `json:"base_scripts_url" default:""`
 	// GeoIP 配置
@@ -56,6 +57,7 @@ const (
 	AutoDiscoveryKeyKey       = "auto_discovery_key"
 	ScriptDomainKey           = "script_domain"
 	SendIpAddrToGuestKey      = "send_ip_addr_to_guest"
+	VisitorAuditEnabledKey    = "visitor_audit_enabled"
 	EulaAcceptedKey           = "eula_accepted"
 	BaseScriptsURLKey         = "base_scripts_url"
 	GeoIpEnabledKey           = "geo_ip_enabled"

--- a/web/rpc/jsonrpc/admin.system.go
+++ b/web/rpc/jsonrpc/admin.system.go
@@ -21,13 +21,23 @@ import (
 	"github.com/komari-monitor/komari/utils/geoip"
 	"github.com/komari-monitor/komari/utils/messageSender"
 	agent_runtime "github.com/komari-monitor/komari/web/agent"
+	"gorm.io/gorm"
 )
 
 // admin.system.go
 // 系统/运维类 RPC2 方法（admin 命名空间）：日志、远程执行、测试。
 
 func init() {
-	reg("getLogs", adminGetLogs, "Get audit logs (paged)")
+	RegisterWithGroupAndMeta("getLogs", rpc.RoleAdmin, adminGetLogs, &rpc.MethodMeta{
+		Name:    "admin:getLogs",
+		Summary: "Get audit logs (paged, optionally filtered by message type)",
+		Params: []rpc.ParamMeta{
+			{Name: "limit", Type: "string", Description: "Page size (default 100)"},
+			{Name: "page", Type: "string", Description: "One-based page number (default 1)"},
+			{Name: "msg_type", Type: "string", Description: "Optional exact message type filter"},
+		},
+		Returns: "{ logs: Log[], total: number }",
+	})
 	reg("exec", adminExec, "Execute a command on clients")
 
 	reg("testSendMessage", adminTestSendMessage, "Send a test notification")
@@ -38,8 +48,9 @@ func init() {
 
 func adminGetLogs(_ context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpcError) {
 	var params struct {
-		Limit string `json:"limit"`
-		Page  string `json:"page"`
+		Limit   string `json:"limit"`
+		Page    string `json:"page"`
+		MsgType string `json:"msg_type"`
 	}
 	req.BindParams(&params)
 	if params.Limit == "" {
@@ -57,16 +68,33 @@ func adminGetLogs(_ context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpc
 		return nil, rpc.MakeError(rpc.InvalidParams, "Invalid page: "+params.Page, nil)
 	}
 	db := dbcore.GetDBInstance()
-	var logs []models.Log
-	offset := (pageInt - 1) * limitInt
-	var total int64
-	if err := db.Model(&models.Log{}).Count(&total).Error; err != nil {
-		return nil, rpc.MakeError(rpc.InternalError, "Failed to count logs: "+err.Error(), nil)
-	}
-	if err := db.Order("time desc").Limit(limitInt).Offset(offset).Find(&logs).Error; err != nil {
+	logs, total, err := queryAdminLogs(db, limitInt, pageInt, params.MsgType)
+	if err != nil {
 		return nil, rpc.MakeError(rpc.InternalError, "Failed to retrieve logs: "+err.Error(), nil)
 	}
 	return map[string]any{"logs": logs, "total": total}, nil
+}
+
+func queryAdminLogs(db *gorm.DB, limit, page int, msgType string) ([]models.Log, int64, error) {
+	var logs []models.Log
+	var total int64
+	offset := (page - 1) * limit
+	countQuery := filterAdminLogsByMessageType(db.Model(&models.Log{}), msgType)
+	logsQuery := filterAdminLogsByMessageType(db.Model(&models.Log{}), msgType)
+	if err := countQuery.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	if err := logsQuery.Order("time desc").Limit(limit).Offset(offset).Find(&logs).Error; err != nil {
+		return nil, 0, err
+	}
+	return logs, total, nil
+}
+
+func filterAdminLogsByMessageType(query *gorm.DB, msgType string) *gorm.DB {
+	if msgType = strings.TrimSpace(msgType); msgType != "" {
+		return query.Where("msg_type = ?", msgType)
+	}
+	return query
 }
 
 func adminExec(ctx context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpcError) {

--- a/web/rpc/jsonrpc/admin.system_test.go
+++ b/web/rpc/jsonrpc/admin.system_test.go
@@ -1,0 +1,53 @@
+package jsonrpc
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/komari-monitor/komari/database/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+	"gorm.io/gorm/schema"
+	gormtests "gorm.io/gorm/utils/tests"
+)
+
+func TestLogSchemaDefinesQueryIndexes(t *testing.T) {
+	parsed, err := schema.Parse(&models.Log{}, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		t.Fatalf("parse log schema: %v", err)
+	}
+	indexes := make(map[string]*schema.Index)
+	for _, index := range parsed.ParseIndexes() {
+		indexes[index.Name] = index
+	}
+	for _, name := range []string{"idx_logs_time", "idx_logs_msg_type_time"} {
+		if indexes[name] == nil {
+			t.Fatalf("expected log index %q to be defined", name)
+		}
+	}
+	composite := indexes["idx_logs_msg_type_time"]
+	if len(composite.Fields) != 2 || composite.Fields[0].Field.Name != "MsgType" || composite.Fields[1].Field.Name != "Time" {
+		t.Fatalf("unexpected composite log index fields: %#v", composite.Fields)
+	}
+}
+
+func TestFilterAdminLogsByMessageType(t *testing.T) {
+	db, err := gorm.Open(gormtests.DummyDialector{}, &gorm.Config{
+		DryRun:               true,
+		DisableAutomaticPing: true,
+		Logger:               logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open dry-run database: %v", err)
+	}
+
+	var logs []models.Log
+	statement := filterAdminLogsByMessageType(db.Model(&models.Log{}), " visitor ").Find(&logs).Statement
+	if sql := statement.SQL.String(); !strings.Contains(sql, "WHERE msg_type = ?") {
+		t.Fatalf("filtered SQL missing message type predicate: %s", sql)
+	}
+	if len(statement.Vars) != 1 || statement.Vars[0] != "visitor" {
+		t.Fatalf("unexpected filter variables: %#v", statement.Vars)
+	}
+}

--- a/web/rpc/jsonrpc/public.audit.go
+++ b/web/rpc/jsonrpc/public.audit.go
@@ -3,21 +3,48 @@ package jsonrpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
+	"sync"
+	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/komari-monitor/komari/database/auditlog"
+	"github.com/komari-monitor/komari/pkg/config"
 	"github.com/komari-monitor/komari/pkg/rpc"
 )
 
 const (
-	visitorAuditMaxEventLen   = 64
-	visitorAuditMaxPathLen    = 512
-	visitorAuditMaxRouteLen   = 128
-	visitorAuditMaxTargetLen  = 128
-	visitorAuditMaxDetailLen  = 2048
-	visitorAuditMaxMessageLen = 4096
+	visitorAuditMaxEventLen     = 64
+	visitorAuditMaxPathLen      = 512
+	visitorAuditMaxRouteLen     = 128
+	visitorAuditMaxTargetLen    = 128
+	visitorAuditMaxUserAgentLen = 512
+	visitorAuditMaxDetailLen    = 2048
+	visitorAuditMaxMessageLen   = 4096
+	visitorAuditRatePerMinute   = 30
+	visitorAuditRateBurst       = 10
+	visitorAuditRateMaxEntries  = 10000
+	visitorAuditLimiterEntryTTL = 10 * time.Minute
+	visitorAuditCleanupInterval = time.Minute
+	visitorAuditMessagePrefix   = "visitor event: "
+	visitorAuditUnknownIPKey    = "<unknown>"
 )
+
+type visitorAuditRateState struct {
+	tokens     float64
+	lastRefill time.Time
+	lastSeen   time.Time
+}
+
+type visitorAuditRateLimiter struct {
+	mu          sync.Mutex
+	entries     map[string]*visitorAuditRateState
+	lastCleanup time.Time
+}
+
+var visitorAuditLimiter = newVisitorAuditRateLimiter()
 
 type visitorAuditParams struct {
 	Event     string         `json:"event"`
@@ -56,16 +83,6 @@ func init() {
 }
 
 func publicRecordVisitorEvent(ctx context.Context, req *rpc.JsonRpcRequest) (any, *rpc.JsonRpcError) {
-	var params visitorAuditParams
-	if err := req.BindParams(&params); err != nil {
-		return nil, rpc.MakeError(rpc.InvalidParams, "Invalid params: "+err.Error(), nil)
-	}
-
-	event := normalizeVisitorAuditEvent(firstNonEmpty(params.Event, params.Action, params.Operation))
-	if event == "" {
-		return nil, rpc.MakeError(rpc.InvalidParams, "event is required", nil)
-	}
-
 	meta := rpc.MetaFromContext(ctx)
 	ip := ""
 	uuid := ""
@@ -76,13 +93,34 @@ func publicRecordVisitorEvent(ctx context.Context, req *rpc.JsonRpcRequest) (any
 		userAgent = meta.UserAgent
 	}
 
+	if !visitorAuditLimiter.Allow(ip, time.Now()) {
+		return map[string]any{"status": "rate_limited"}, nil
+	}
+	enabled, err := config.GetAs[bool](config.VisitorAuditEnabledKey, false)
+	if err != nil {
+		return nil, rpc.MakeError(rpc.InternalError, "Failed to get visitor audit configuration", nil)
+	}
+	if !enabled {
+		return map[string]any{"status": "disabled"}, nil
+	}
+
+	var params visitorAuditParams
+	if err := req.BindParams(&params); err != nil {
+		return nil, rpc.MakeError(rpc.InvalidParams, "Invalid params: "+err.Error(), nil)
+	}
+
+	event := normalizeVisitorAuditEvent(firstNonEmpty(params.Event, params.Action, params.Operation))
+	if event == "" {
+		return nil, rpc.MakeError(rpc.InvalidParams, "event is required", nil)
+	}
+
 	message, err := buildVisitorAuditMessage(visitorAuditMessage{
 		Event:     event,
-		Path:      truncateString(strings.TrimSpace(params.Path), visitorAuditMaxPathLen),
-		Route:     truncateString(strings.TrimSpace(params.Route), visitorAuditMaxRouteLen),
-		Target:    truncateString(strings.TrimSpace(params.Target), visitorAuditMaxTargetLen),
-		UserAgent: truncateString(strings.TrimSpace(userAgent), visitorAuditMaxPathLen),
-		Detail:    trimVisitorAuditDetail(params.Detail),
+		Path:      strings.TrimSpace(params.Path),
+		Route:     strings.TrimSpace(params.Route),
+		Target:    strings.TrimSpace(params.Target),
+		UserAgent: strings.TrimSpace(userAgent),
+		Detail:    params.Detail,
 	})
 	if err != nil {
 		return nil, rpc.MakeError(rpc.InvalidParams, "Invalid detail", nil)
@@ -92,13 +130,56 @@ func publicRecordVisitorEvent(ctx context.Context, req *rpc.JsonRpcRequest) (any
 	return map[string]any{"status": "success"}, nil
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
+func newVisitorAuditRateLimiter() *visitorAuditRateLimiter {
+	return &visitorAuditRateLimiter{entries: make(map[string]*visitorAuditRateState)}
+}
+
+func (l *visitorAuditRateLimiter) Allow(ip string, now time.Time) bool {
+	key := strings.TrimSpace(ip)
+	if key == "" {
+		key = visitorAuditUnknownIPKey
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.lastCleanup.IsZero() || now.Sub(l.lastCleanup) >= visitorAuditCleanupInterval {
+		l.cleanupLocked(now)
+	}
+
+	state, ok := l.entries[key]
+	if !ok {
+		if len(l.entries) >= visitorAuditRateMaxEntries {
+			return false
+		}
+		l.entries[key] = &visitorAuditRateState{
+			tokens:     visitorAuditRateBurst - 1,
+			lastRefill: now,
+			lastSeen:   now,
+		}
+		return true
+	}
+
+	if now.After(state.lastRefill) {
+		elapsedMinutes := now.Sub(state.lastRefill).Minutes()
+		state.tokens = min(float64(visitorAuditRateBurst), state.tokens+elapsedMinutes*visitorAuditRatePerMinute)
+		state.lastRefill = now
+	}
+	state.lastSeen = now
+	if state.tokens < 1 {
+		return false
+	}
+	state.tokens--
+	return true
+}
+
+func (l *visitorAuditRateLimiter) cleanupLocked(now time.Time) {
+	for key, state := range l.entries {
+		if now.Sub(state.lastSeen) >= visitorAuditLimiterEntryTTL {
+			delete(l.entries, key)
 		}
 	}
-	return ""
+	l.lastCleanup = now
 }
 
 func normalizeVisitorAuditEvent(event string) string {
@@ -108,18 +189,26 @@ func normalizeVisitorAuditEvent(event string) string {
 	}
 	var builder strings.Builder
 	builder.Grow(len(event))
+	written := 0
 	for _, r := range event {
+		allowed := false
 		switch {
 		case r == '_' || r == '-' || r == ':' || r == '.':
-			builder.WriteRune(r)
+			allowed = true
 		case unicode.IsLetter(r) || unicode.IsDigit(r):
-			builder.WriteRune(r)
+			allowed = true
 		case unicode.IsSpace(r):
-			builder.WriteByte('_')
+			r = '_'
+			allowed = true
 		}
-		if builder.Len() >= visitorAuditMaxEventLen {
+		if !allowed {
+			continue
+		}
+		if written >= visitorAuditMaxEventLen {
 			break
 		}
+		builder.WriteRune(r)
+		written++
 	}
 	return builder.String()
 }
@@ -139,20 +228,61 @@ func trimVisitorAuditDetail(detail map[string]any) map[string]any {
 }
 
 func buildVisitorAuditMessage(message visitorAuditMessage) (string, error) {
-	encoded, err := json.Marshal(message)
-	if err != nil {
-		return "", err
+	message.Event = truncateString(strings.TrimSpace(message.Event), visitorAuditMaxEventLen)
+	message.Path = truncateString(strings.TrimSpace(message.Path), visitorAuditMaxPathLen)
+	message.Route = truncateString(strings.TrimSpace(message.Route), visitorAuditMaxRouteLen)
+	message.Target = truncateString(strings.TrimSpace(message.Target), visitorAuditMaxTargetLen)
+	message.UserAgent = truncateString(strings.TrimSpace(message.UserAgent), visitorAuditMaxUserAgentLen)
+	message.Detail = trimVisitorAuditDetail(message.Detail)
+
+	detailReduced := false
+	for {
+		encoded, err := json.Marshal(message)
+		if err != nil {
+			return "", err
+		}
+		if len(visitorAuditMessagePrefix)+len(encoded) <= visitorAuditMaxMessageLen {
+			return visitorAuditMessagePrefix + string(encoded), nil
+		}
+
+		if message.Detail != nil && !detailReduced {
+			message.Detail = map[string]any{"truncated": true}
+			detailReduced = true
+			continue
+		}
+		if !shrinkLongestVisitorAuditField(&message) {
+			return "", errors.New("visitor audit message exceeds maximum length")
+		}
 	}
-	text := "visitor event: " + string(encoded)
-	return truncateString(text, visitorAuditMaxMessageLen), nil
+}
+
+func shrinkLongestVisitorAuditField(message *visitorAuditMessage) bool {
+	fields := []*string{&message.Path, &message.UserAgent, &message.Route, &message.Target}
+	var longest *string
+	longestLen := 0
+	for _, field := range fields {
+		if size := utf8.RuneCountInString(*field); size > longestLen {
+			longest = field
+			longestLen = size
+		}
+	}
+	if longest == nil {
+		return false
+	}
+	*longest = truncateString(*longest, longestLen/2)
+	return true
 }
 
 func truncateString(value string, limit int) string {
-	if limit <= 0 || len(value) <= limit {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(value)
+	if len(runes) <= limit {
 		return value
 	}
 	if limit <= 3 {
-		return value[:limit]
+		return string(runes[:limit])
 	}
-	return value[:limit-3] + "..."
+	return string(runes[:limit-3]) + "..."
 }

--- a/web/rpc/jsonrpc/public.audit_test.go
+++ b/web/rpc/jsonrpc/public.audit_test.go
@@ -1,6 +1,13 @@
 package jsonrpc
 
-import "testing"
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
 
 func TestNormalizeVisitorAuditEvent(t *testing.T) {
 	cases := map[string]string{
@@ -14,6 +21,11 @@ func TestNormalizeVisitorAuditEvent(t *testing.T) {
 		if got := normalizeVisitorAuditEvent(input); got != want {
 			t.Fatalf("normalizeVisitorAuditEvent(%q) = %q, want %q", input, got, want)
 		}
+	}
+
+	got := normalizeVisitorAuditEvent(strings.Repeat("访", visitorAuditMaxEventLen+10))
+	if utf8.RuneCountInString(got) != visitorAuditMaxEventLen || !utf8.ValidString(got) {
+		t.Fatalf("expected a valid %d-rune event, got %q", visitorAuditMaxEventLen, got)
 	}
 }
 
@@ -31,11 +43,94 @@ func TestTrimVisitorAuditDetail(t *testing.T) {
 }
 
 func TestBuildVisitorAuditMessage(t *testing.T) {
-	message, err := buildVisitorAuditMessage(visitorAuditMessage{Event: "page_view", Path: "/"})
+	message, err := buildVisitorAuditMessage(visitorAuditMessage{
+		Event:     "page_view",
+		Path:      strings.Repeat("\x01中文", visitorAuditMaxPathLen),
+		Route:     strings.Repeat("路由", visitorAuditMaxRouteLen),
+		Target:    strings.Repeat("目标", visitorAuditMaxTargetLen),
+		UserAgent: strings.Repeat("浏览器", visitorAuditMaxUserAgentLen),
+		Detail:    map[string]any{"data": strings.Repeat("详情", visitorAuditMaxDetailLen)},
+	})
 	if err != nil {
 		t.Fatalf("buildVisitorAuditMessage returned error: %v", err)
 	}
-	if message == "" || len(message) > visitorAuditMaxMessageLen {
+	if message == "" || len(message) > visitorAuditMaxMessageLen || !utf8.ValidString(message) {
 		t.Fatalf("unexpected message length %d", len(message))
+	}
+	encoded, ok := strings.CutPrefix(message, visitorAuditMessagePrefix)
+	if !ok {
+		t.Fatalf("message missing prefix: %q", message)
+	}
+	var decoded visitorAuditMessage
+	if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+		t.Fatalf("message JSON is invalid: %v", err)
+	}
+	if decoded.Event != "page_view" {
+		t.Fatalf("unexpected event after bounding message: %q", decoded.Event)
+	}
+}
+
+func TestBuildVisitorAuditMessageBoundsUserAgentByRunes(t *testing.T) {
+	message, err := buildVisitorAuditMessage(visitorAuditMessage{
+		Event:     "page_view",
+		UserAgent: strings.Repeat("访", visitorAuditMaxUserAgentLen+20),
+	})
+	if err != nil {
+		t.Fatalf("buildVisitorAuditMessage returned error: %v", err)
+	}
+	encoded, _ := strings.CutPrefix(message, visitorAuditMessagePrefix)
+	var decoded visitorAuditMessage
+	if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+		t.Fatalf("message JSON is invalid: %v", err)
+	}
+	if got := utf8.RuneCountInString(decoded.UserAgent); got != visitorAuditMaxUserAgentLen {
+		t.Fatalf("user agent length = %d, want %d", got, visitorAuditMaxUserAgentLen)
+	}
+}
+
+func TestTruncateStringPreservesUTF8(t *testing.T) {
+	got := truncateString("中文路径测试", 4)
+	if got != "中..." || !utf8.ValidString(got) {
+		t.Fatalf("truncateString returned %q", got)
+	}
+}
+
+func TestVisitorAuditRateLimiter(t *testing.T) {
+	limiter := newVisitorAuditRateLimiter()
+	now := time.Unix(1000, 0)
+	for i := 0; i < visitorAuditRateBurst; i++ {
+		if !limiter.Allow("192.0.2.1", now) {
+			t.Fatalf("request %d within burst was rejected", i+1)
+		}
+	}
+	if limiter.Allow("192.0.2.1", now) {
+		t.Fatal("request over burst was allowed")
+	}
+	if !limiter.Allow("192.0.2.1", now.Add(2*time.Second)) {
+		t.Fatal("token was not refilled at 30 requests per minute")
+	}
+
+	cleanupAt := now.Add(2*time.Second + visitorAuditLimiterEntryTTL)
+	if !limiter.Allow("192.0.2.2", cleanupAt) {
+		t.Fatal("request from a new IP was rejected")
+	}
+	if _, ok := limiter.entries["192.0.2.1"]; ok {
+		t.Fatal("stale limiter entry was not cleaned up")
+	}
+}
+
+func TestVisitorAuditRateLimiterCapsTrackedIPs(t *testing.T) {
+	limiter := newVisitorAuditRateLimiter()
+	now := time.Unix(1000, 0)
+	for i := 0; i < visitorAuditRateMaxEntries; i++ {
+		if !limiter.Allow(strconv.Itoa(i), now) {
+			t.Fatalf("IP %d was rejected before the limiter reached capacity", i)
+		}
+	}
+	if limiter.Allow("overflow", now) {
+		t.Fatal("new IP was allowed after the limiter reached capacity")
+	}
+	if !limiter.Allow("0", now) {
+		t.Fatal("tracked IP was rejected after the limiter reached capacity")
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up hardening for #597 after the merged snapshot build exposed a package-level compile conflict.

- remove the duplicate `firstNonEmpty` declaration that broke every binary build in [run 29385359300](https://github.com/komari-monitor/komari/actions/runs/29385359300)
- gate visitor audit writes behind a new `visitor_audit_enabled` setting that defaults to `false`
- add a bounded in-memory per-IP token bucket (30/minute, burst 10, 10-minute entry TTL, 10,000 tracked-IP cap) without a new dependency
- bound strings by Unicode code points and shrink fields/detail before JSON serialization, so stored messages remain valid UTF-8 and complete JSON
- add a dedicated User-Agent length limit
- add a `time` index and a `(msg_type, time)` composite index to `models.Log`
- add optional SQL-level `msg_type` filtering to `admin:getLogs`, including filtered totals

## Security and compatibility

- Existing and new installations keep visitor audit writes disabled until an administrator explicitly enables them.
- `public:recordVisitorEvent` intentionally remains in the private-site login whitelist so themes can record pre-login events when the setting is enabled.
- Disabled and rate-limited calls return a normal status and do not write to the database, preserving fire-and-forget frontend behavior.
- `visitor_audit_enabled` is exposed by `public:getPublicSettings` so themes can avoid unnecessary calls.

## Validation

- `go test ./web/rpc/jsonrpc ./database/models ./pkg/config`
- `go vet ./web/rpc/jsonrpc ./database/models ./pkg/config`
- `git diff --check`

The repository-wide local test command still requires the generated `web/public/defaultTheme` frontend artifact and a CGO-enabled SQLite toolchain. The pull-request build workflow supplies both. A compile-only pass with a temporary embed fixture compiled all packages; the remaining local failure was the existing `CGO_ENABLED=0` SQLite stub during package initialization.

## Non-goals

This PR does not add a dedicated visitor-event table or a framework-wide RPC request-body limit. Those are broader follow-ups and are not required for this focused post-merge hardening fix.
