### PR TITLE
feat: add real-time billing estimates

### DIFF
--- a/database/clients/billing.go
+++ b/database/clients/billing.go
@@ -75,6 +75,9 @@ func calculateBillingUsageUpdates(client models.Client, report v1.Report, now ti
 		"billing_last_total_down":      report.Network.TotalDown,
 		"billing_traffic_baseline_set": true,
 	}
+	if !client.BillingStartupFeeApplied {
+		updates["billing_startup_fee_applied"] = true
+	}
 
 	if client.FirstAgentReportedAt.ToTime().IsZero() {
 		updates["first_agent_reported_at"] = models.FromTime(now)

--- a/database/clients/billing.go
+++ b/database/clients/billing.go
@@ -1,0 +1,124 @@
+package clients
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/komari-monitor/komari/database/dbcore"
+	"github.com/komari-monitor/komari/database/models"
+	v1 "github.com/komari-monitor/komari/protocol/v1"
+	"github.com/komari-monitor/komari/utils"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const billingPersistInterval = 30 * time.Second
+
+var (
+	billingUsageMu       sync.Mutex
+	billingLastPersisted = make(map[string]time.Time)
+)
+
+// UpdateBillingUsage records the counters needed for a live cost estimate. It
+// deliberately stores usage, not invoice rows: changing a rate recalculates the
+// estimate and does not rewrite a historical ledger.
+func UpdateBillingUsage(uuid string, report v1.Report) error {
+	if err := ReportVerify(report); err != nil {
+		return err
+	}
+
+	billingUsageMu.Lock()
+	defer billingUsageMu.Unlock()
+	if lastPersisted, ok := billingLastPersisted[uuid]; ok {
+		elapsed := report.UpdatedAt.Sub(lastPersisted)
+		if elapsed >= 0 && elapsed < billingPersistInterval {
+			return nil
+		}
+	}
+
+	err := dbcore.GetDBInstance().Transaction(func(tx *gorm.DB) error {
+		var client models.Client
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("uuid = ?", uuid).First(&client).Error; err != nil {
+			return fmt.Errorf("load client billing state: %w", err)
+		}
+
+		updates := calculateBillingUsageUpdates(client, report, report.UpdatedAt)
+		if len(updates) == 0 {
+			return nil
+		}
+		if err := tx.Model(&models.Client{}).Where("uuid = ?", uuid).Updates(updates).Error; err != nil {
+			return fmt.Errorf("update client billing state: %w", err)
+		}
+		return nil
+	})
+	if err == nil {
+		billingLastPersisted[uuid] = report.UpdatedAt
+	}
+	return err
+}
+
+func forgetBillingUsage(uuid string) {
+	billingUsageMu.Lock()
+	delete(billingLastPersisted, uuid)
+	billingUsageMu.Unlock()
+}
+
+func calculateBillingUsageUpdates(client models.Client, report v1.Report, now time.Time) map[string]interface{} {
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	updates := map[string]interface{}{
+		"billing_last_total_up":        report.Network.TotalUp,
+		"billing_last_total_down":      report.Network.TotalDown,
+		"billing_traffic_baseline_set": true,
+	}
+
+	if client.FirstAgentReportedAt.ToTime().IsZero() {
+		updates["first_agent_reported_at"] = models.FromTime(now)
+		updates["first_agent_reported_at_estimated"] = false
+	}
+
+	if client.ExpiredAt.ToTime().IsZero() {
+		updates["expired_at"] = models.FromTime(nextNaturalMonth(now))
+	}
+
+	// The first report establishes a baseline. Existing OS counters may include
+	// traffic from before Komari was installed and must not be charged.
+	if !client.BillingTrafficBaselineSet {
+		return updates
+	}
+
+	deltaUp := utils.ComputeTrafficDelta(report.Network.TotalUp, client.BillingLastTotalUp)
+	deltaDown := utils.ComputeTrafficDelta(report.Network.TotalDown, client.BillingLastTotalDown)
+	updates["billing_traffic_bytes"] = saturatingAdd(client.BillingTrafficBytes, deltaUp, deltaDown)
+	return updates
+}
+
+func nextNaturalMonth(value time.Time) time.Time {
+	firstOfNextMonth := time.Date(value.Year(), value.Month()+1, 1, value.Hour(), value.Minute(), value.Second(), value.Nanosecond(), value.Location())
+	lastOfNextMonth := firstOfNextMonth.AddDate(0, 1, -1).Day()
+	day := value.Day()
+	if day > lastOfNextMonth {
+		day = lastOfNextMonth
+	}
+	return time.Date(firstOfNextMonth.Year(), firstOfNextMonth.Month(), day, value.Hour(), value.Minute(), value.Second(), value.Nanosecond(), value.Location())
+}
+
+func saturatingAdd(base int64, values ...int64) int64 {
+	if base < 0 {
+		base = 0
+	}
+	for _, value := range values {
+		if value <= 0 {
+			continue
+		}
+		if value > math.MaxInt64-base {
+			return math.MaxInt64
+		}
+		base += value
+	}
+	return base
+}

--- a/database/clients/billing_test.go
+++ b/database/clients/billing_test.go
@@ -21,6 +21,7 @@ func TestCalculateBillingUsageUpdatesInitializesFirstReport(t *testing.T) {
 
 	assert.Equal(t, models.FromTime(now), updates["first_agent_reported_at"])
 	assert.Equal(t, models.FromTime(time.Date(2026, time.February, 28, 12, 0, 0, 0, time.UTC)), updates["expired_at"])
+	assert.Equal(t, true, updates["billing_startup_fee_applied"])
 	assert.Equal(t, int64(100), updates["billing_last_total_up"])
 	assert.Equal(t, int64(200), updates["billing_last_total_down"])
 	_, hasTraffic := updates["billing_traffic_bytes"]
@@ -41,6 +42,20 @@ func TestCalculateBillingUsageUpdatesPreservesEstimatedAnchor(t *testing.T) {
 	_, overwroteAnchor := updates["first_agent_reported_at"]
 	assert.False(t, overwroteAnchor)
 	assert.Equal(t, models.FromTime(now.AddDate(0, 1, 0)), updates["expired_at"])
+	assert.Equal(t, true, updates["billing_startup_fee_applied"])
+}
+
+func TestCalculateBillingUsageUpdatesKeepsAppliedStartupFee(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC)
+	client := models.Client{
+		FirstAgentReportedAt:     models.FromTime(now.Add(-time.Hour)),
+		BillingStartupFeeApplied: true,
+	}
+
+	updates := calculateBillingUsageUpdates(client, v1.Report{UpdatedAt: now}, now)
+
+	_, rewroteStartupFeeState := updates["billing_startup_fee_applied"]
+	assert.False(t, rewroteStartupFeeState)
 }
 
 func TestCalculateBillingUsageUpdatesHandlesCounterReset(t *testing.T) {

--- a/database/clients/billing_test.go
+++ b/database/clients/billing_test.go
@@ -1,0 +1,67 @@
+package clients
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/komari-monitor/komari/database/models"
+	v1 "github.com/komari-monitor/komari/protocol/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateBillingUsageUpdatesInitializesFirstReport(t *testing.T) {
+	now := time.Date(2026, time.January, 31, 12, 0, 0, 0, time.UTC)
+	report := v1.Report{UpdatedAt: now}
+	report.Network.TotalUp = 100
+	report.Network.TotalDown = 200
+
+	updates := calculateBillingUsageUpdates(models.Client{}, report, now)
+
+	assert.Equal(t, models.FromTime(now), updates["first_agent_reported_at"])
+	assert.Equal(t, models.FromTime(time.Date(2026, time.February, 28, 12, 0, 0, 0, time.UTC)), updates["expired_at"])
+	assert.Equal(t, int64(100), updates["billing_last_total_up"])
+	assert.Equal(t, int64(200), updates["billing_last_total_down"])
+	_, hasTraffic := updates["billing_traffic_bytes"]
+	assert.False(t, hasTraffic)
+}
+
+func TestCalculateBillingUsageUpdatesPreservesEstimatedAnchor(t *testing.T) {
+	createdAt := time.Date(2025, time.December, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC)
+	client := models.Client{
+		FirstAgentReportedAt:          models.FromTime(createdAt),
+		FirstAgentReportedAtEstimated: true,
+	}
+	report := v1.Report{UpdatedAt: now}
+
+	updates := calculateBillingUsageUpdates(client, report, now)
+
+	_, overwroteAnchor := updates["first_agent_reported_at"]
+	assert.False(t, overwroteAnchor)
+	assert.Equal(t, models.FromTime(now.AddDate(0, 1, 0)), updates["expired_at"])
+}
+
+func TestCalculateBillingUsageUpdatesHandlesCounterReset(t *testing.T) {
+	now := time.Date(2026, time.July, 15, 0, 0, 0, 0, time.UTC)
+	client := models.Client{
+		FirstAgentReportedAt:      models.FromTime(now.Add(-time.Hour)),
+		BillingTrafficBaselineSet: true,
+		BillingTrafficBytes:       500,
+		BillingLastTotalUp:        1000,
+		BillingLastTotalDown:      2000,
+	}
+	report := v1.Report{UpdatedAt: now}
+	report.Network.TotalUp = 25
+	report.Network.TotalDown = 40
+
+	updates := calculateBillingUsageUpdates(client, report, now)
+
+	assert.Equal(t, int64(565), updates["billing_traffic_bytes"])
+}
+
+func TestSaturatingAddPreventsOverflow(t *testing.T) {
+	result := saturatingAdd(math.MaxInt64-2, 1, 5)
+	require.Equal(t, int64(math.MaxInt64), result)
+}

--- a/database/clients/client.go
+++ b/database/clients/client.go
@@ -22,6 +22,7 @@ func DeleteClient(clientUuid string) error {
 	if err != nil {
 		return err
 	}
+	forgetBillingUsage(clientUuid)
 	return nil
 }
 
@@ -260,6 +261,31 @@ func SaveClient(updates map[string]interface{}) error {
 				return fmt.Errorf("traffic_limit must be a valid non-negative int64 value, got %v", val)
 			}
 		}
+	}
+
+	for _, key := range []string{
+		"billing_traffic_bytes",
+		"billing_last_total_up",
+		"billing_last_total_down",
+		"billing_traffic_baseline_set",
+		"first_agent_reported_at_estimated",
+	} {
+		if _, exists := updates[key]; exists {
+			return fmt.Errorf("%s is managed by the server", key)
+		}
+	}
+
+	for _, key := range []string{"traffic_rate", "time_rate", "startup_fee"} {
+		if value, exists := updates[key]; exists {
+			numericValue, ok := value.(float64)
+			if !ok || math.IsNaN(numericValue) || math.IsInf(numericValue, 0) || numericValue < 0 || numericValue > 1e12 {
+				return fmt.Errorf("%s must be a finite non-negative number no greater than 1e12", key)
+			}
+		}
+	}
+
+	if _, exists := updates["first_agent_reported_at"]; exists {
+		updates["first_agent_reported_at_estimated"] = false
 	}
 
 	updates["updated_at"] = time.Now()

--- a/database/clients/client.go
+++ b/database/clients/client.go
@@ -265,6 +265,7 @@ func SaveClient(updates map[string]interface{}) error {
 
 	for _, key := range []string{
 		"billing_traffic_bytes",
+		"billing_startup_fee_applied",
 		"billing_last_total_up",
 		"billing_last_total_down",
 		"billing_traffic_baseline_set",

--- a/database/dbcore/dbcore.go
+++ b/database/dbcore/dbcore.go
@@ -425,6 +425,8 @@ func doInitialize() error {
 	// 基于配置中的版本标记检测升级并自动备份 ./data，便于回滚。
 	backupOnVersionUpgrade()
 
+	hadBillingAnchorColumn := instance.Migrator().HasColumn(&models.Client{}, "FirstAgentReportedAt")
+
 	// 自动迁移模型
 	//
 	// 注意：负载/GPU/ping 历史监控数据运行期全部走 metric store（默认 SQLite
@@ -449,6 +451,11 @@ func doInitialize() error {
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create tables: %w", err)
+	}
+	if !hadBillingAnchorColumn {
+		if err := migrations.BackfillClientBillingAnchors(instance); err != nil {
+			return fmt.Errorf("failed to backfill client billing anchors: %w", err)
+		}
 	}
 	if err := instance.AutoMigrate(
 		&models.Session{},

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -8,39 +8,48 @@ import (
 
 // Client represents a registered client device
 type Client struct {
-	UUID             string    `json:"uuid,omitempty" gorm:"type:varchar(36);primaryKey"`
-	Token            string    `json:"token,omitempty" gorm:"type:varchar(255);unique;not null"`
-	Name             string    `json:"name" gorm:"type:varchar(100)"`
-	CpuName          string    `json:"cpu_name" gorm:"type:varchar(100)"`
-	Virtualization   string    `json:"virtualization" gorm:"type:varchar(50)"`
-	Arch             string    `json:"arch" gorm:"type:varchar(50)"`
-	CpuCores         int       `json:"cpu_cores" gorm:"type:int"`
-	CpuPhysicalCores int       `json:"cpu_physical_cores" gorm:"type:int"`
-	OS               string    `json:"os" gorm:"type:varchar(100)"`
-	KernelVersion    string    `json:"kernel_version" gorm:"type:varchar(100)"`
-	GpuName          string    `json:"gpu_name" gorm:"type:varchar(100)"`
-	IPv4             string    `json:"ipv4,omitempty" gorm:"type:varchar(100)"`
-	IPv6             string    `json:"ipv6,omitempty" gorm:"type:varchar(100)"`
-	Region           string    `json:"region" gorm:"type:varchar(100)"`
-	Remark           string    `json:"remark,omitempty" gorm:"type:longtext"`
-	PublicRemark     string    `json:"public_remark,omitempty" gorm:"type:longtext"`
-	MemTotal         int64     `json:"mem_total" gorm:"type:bigint"`
-	SwapTotal        int64     `json:"swap_total" gorm:"type:bigint"`
-	DiskTotal        int64     `json:"disk_total" gorm:"type:bigint"`
-	Version          string    `json:"version,omitempty" gorm:"type:varchar(100)"`
-	Weight           int       `json:"weight" gorm:"type:int"`
-	Price            float64   `json:"price"`
-	BillingCycle     int       `json:"billing_cycle"`
-	AutoRenewal      bool      `json:"auto_renewal" gorm:"default:false"` // 是否自动续费
-	Currency         string    `json:"currency" gorm:"type:varchar(20);default:'$'"`
-	ExpiredAt        LocalTime `json:"expired_at" gorm:"type:timestamp"`
-	Group            string    `json:"group" gorm:"type:varchar(100)"`
-	Tags             string    `json:"tags" gorm:"type:text"` // split by ';'
-	Hidden           bool      `json:"hidden" gorm:"default:false"`
-	TrafficLimit     int64     `json:"traffic_limit" gorm:"type:bigint"`
-	TrafficLimitType string    `json:"traffic_limit_type" gorm:"type:varchar(10);default:'max'"` // 流量阈值类型：sum max min up down
-	CreatedAt        LocalTime `json:"created_at"`
-	UpdatedAt        LocalTime `json:"updated_at"`
+	UUID                          string    `json:"uuid,omitempty" gorm:"type:varchar(36);primaryKey"`
+	Token                         string    `json:"token,omitempty" gorm:"type:varchar(255);unique;not null"`
+	Name                          string    `json:"name" gorm:"type:varchar(100)"`
+	CpuName                       string    `json:"cpu_name" gorm:"type:varchar(100)"`
+	Virtualization                string    `json:"virtualization" gorm:"type:varchar(50)"`
+	Arch                          string    `json:"arch" gorm:"type:varchar(50)"`
+	CpuCores                      int       `json:"cpu_cores" gorm:"type:int"`
+	CpuPhysicalCores              int       `json:"cpu_physical_cores" gorm:"type:int"`
+	OS                            string    `json:"os" gorm:"type:varchar(100)"`
+	KernelVersion                 string    `json:"kernel_version" gorm:"type:varchar(100)"`
+	GpuName                       string    `json:"gpu_name" gorm:"type:varchar(100)"`
+	IPv4                          string    `json:"ipv4,omitempty" gorm:"type:varchar(100)"`
+	IPv6                          string    `json:"ipv6,omitempty" gorm:"type:varchar(100)"`
+	Region                        string    `json:"region" gorm:"type:varchar(100)"`
+	Remark                        string    `json:"remark,omitempty" gorm:"type:longtext"`
+	PublicRemark                  string    `json:"public_remark,omitempty" gorm:"type:longtext"`
+	MemTotal                      int64     `json:"mem_total" gorm:"type:bigint"`
+	SwapTotal                     int64     `json:"swap_total" gorm:"type:bigint"`
+	DiskTotal                     int64     `json:"disk_total" gorm:"type:bigint"`
+	Version                       string    `json:"version,omitempty" gorm:"type:varchar(100)"`
+	Weight                        int       `json:"weight" gorm:"type:int"`
+	Price                         float64   `json:"price"`
+	BillingCycle                  int       `json:"billing_cycle"`
+	AutoRenewal                   bool      `json:"auto_renewal" gorm:"default:false"` // 是否自动续费
+	Currency                      string    `json:"currency" gorm:"type:varchar(20);default:'$'"`
+	ExpiredAt                     LocalTime `json:"expired_at" gorm:"type:timestamp"`
+	TrafficRate                   float64   `json:"traffic_rate" gorm:"default:0"` // 每 TiB 流量的实时估算单价
+	TimeRate                      float64   `json:"time_rate" gorm:"default:0"`    // 每小时运行时间的实时估算单价
+	StartupFee                    float64   `json:"startup_fee" gorm:"default:0"`  // 首次成功上报时计入一次
+	FirstAgentReportedAt          LocalTime `json:"first_agent_reported_at" gorm:"type:timestamp"`
+	FirstAgentReportedAtEstimated bool      `json:"first_agent_reported_at_estimated" gorm:"default:false"`
+	BillingTrafficBytes           int64     `json:"billing_traffic_bytes" gorm:"type:bigint;default:0"`
+	BillingLastTotalUp            int64     `json:"-" gorm:"type:bigint;default:0"`
+	BillingLastTotalDown          int64     `json:"-" gorm:"type:bigint;default:0"`
+	BillingTrafficBaselineSet     bool      `json:"-" gorm:"default:false"`
+	Group                         string    `json:"group" gorm:"type:varchar(100)"`
+	Tags                          string    `json:"tags" gorm:"type:text"` // split by ';'
+	Hidden                        bool      `json:"hidden" gorm:"default:false"`
+	TrafficLimit                  int64     `json:"traffic_limit" gorm:"type:bigint"`
+	TrafficLimitType              string    `json:"traffic_limit_type" gorm:"type:varchar(10);default:'max'"` // 流量阈值类型：sum max min up down
+	CreatedAt                     LocalTime `json:"created_at"`
+	UpdatedAt                     LocalTime `json:"updated_at"`
 }
 
 // User represents an authenticated user

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -34,7 +34,7 @@ type Client struct {
 	AutoRenewal                   bool      `json:"auto_renewal" gorm:"default:false"` // 是否自动续费
 	Currency                      string    `json:"currency" gorm:"type:varchar(20);default:'$'"`
 	ExpiredAt                     LocalTime `json:"expired_at" gorm:"type:timestamp"`
-	TrafficRate                   float64   `json:"traffic_rate" gorm:"default:0"` // 每 TiB 流量的实时估算单价
+	TrafficRate                   float64   `json:"traffic_rate" gorm:"default:0"` // 每 TiB（1024^4 bytes）流量的实时估算单价
 	TimeRate                      float64   `json:"time_rate" gorm:"default:0"`    // 每小时运行时间的实时估算单价
 	StartupFee                    float64   `json:"startup_fee" gorm:"default:0"`  // 首次成功上报时计入一次
 	FirstAgentReportedAt          LocalTime `json:"first_agent_reported_at" gorm:"type:timestamp"`

--- a/database/models/models.go
+++ b/database/models/models.go
@@ -39,6 +39,7 @@ type Client struct {
 	StartupFee                    float64   `json:"startup_fee" gorm:"default:0"`  // 首次成功上报时计入一次
 	FirstAgentReportedAt          LocalTime `json:"first_agent_reported_at" gorm:"type:timestamp"`
 	FirstAgentReportedAtEstimated bool      `json:"first_agent_reported_at_estimated" gorm:"default:false"`
+	BillingStartupFeeApplied      bool      `json:"billing_startup_fee_applied" gorm:"default:false"`
 	BillingTrafficBytes           int64     `json:"billing_traffic_bytes" gorm:"type:bigint;default:0"`
 	BillingLastTotalUp            int64     `json:"-" gorm:"type:bigint;default:0"`
 	BillingLastTotalDown          int64     `json:"-" gorm:"type:bigint;default:0"`

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -129,6 +129,21 @@ func Run(ctx Context) error {
 	return nil
 }
 
+// BackfillClientBillingAnchors marks pre-feature clients as estimates based on
+// their creation time. It is called only when the billing anchor column is first
+// introduced, after AutoMigrate has created the new columns.
+func BackfillClientBillingAnchors(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("migration database is nil")
+	}
+	return db.Model(&models.Client{}).
+		Where("first_agent_reported_at IS NULL AND created_at IS NOT NULL").
+		Updates(map[string]interface{}{
+			"first_agent_reported_at":           gorm.Expr("created_at"),
+			"first_agent_reported_at_estimated": true,
+		}).Error
+}
+
 func hasLegacyConfigTable(db *gorm.DB) bool {
 	if !db.Migrator().HasTable("configs") {
 		return false

--- a/web/api/client/ingest.go
+++ b/web/api/client/ingest.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"log"
 	"time"
 
 	"github.com/komari-monitor/komari/database/clients"
@@ -23,15 +24,19 @@ func ingestReport(uuid string, report v1.Report, protocolVersion int, markPresen
 	if err != nil {
 		return err
 	}
-	if err := clients.UpdateBillingUsage(uuid, savedReport); err != nil {
-		return err
-	}
+	updateBillingUsageBestEffort(uuid, savedReport, clients.UpdateBillingUsage)
 	agent_runtime.SetLatestReport(uuid, &savedReport)
 	agent_runtime.SetClientProtocolVersion(uuid, protocolVersion)
 	if markPresence {
 		refreshPostPresence(uuid)
 	}
 	return nil
+}
+
+func updateBillingUsageBestEffort(uuid string, report v1.Report, update func(string, v1.Report) error) {
+	if err := update(uuid, report); err != nil {
+		log.Printf("Failed to update billing usage for client %s: %v", uuid, err)
+	}
 }
 
 // ingestBasicInfo 保存客户端基础信息。fallbackIP 在上报未携带 IP 时用作兜底。

--- a/web/api/client/ingest.go
+++ b/web/api/client/ingest.go
@@ -3,6 +3,7 @@ package client
 import (
 	"time"
 
+	"github.com/komari-monitor/komari/database/clients"
 	"github.com/komari-monitor/komari/database/models"
 	"github.com/komari-monitor/komari/database/tasks"
 	v1 "github.com/komari-monitor/komari/protocol/v1"
@@ -20,6 +21,9 @@ func ingestReport(uuid string, report v1.Report, protocolVersion int, markPresen
 	report.UUID = uuid
 	savedReport, err := SaveClientReport(uuid, report)
 	if err != nil {
+		return err
+	}
+	if err := clients.UpdateBillingUsage(uuid, savedReport); err != nil {
 		return err
 	}
 	agent_runtime.SetLatestReport(uuid, &savedReport)

--- a/web/api/client/ingest_test.go
+++ b/web/api/client/ingest_test.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+
+	v1 "github.com/komari-monitor/komari/protocol/v1"
+)
+
+func TestUpdateBillingUsageBestEffortLogsAndContinues(t *testing.T) {
+	var output bytes.Buffer
+	previousWriter := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() {
+		log.SetOutput(previousWriter)
+	})
+
+	called := false
+	updateBillingUsageBestEffort("node-1", v1.Report{}, func(string, v1.Report) error {
+		called = true
+		return errors.New("database locked")
+	})
+
+	if !called {
+		t.Fatal("billing updater was not called")
+	}
+	if message := output.String(); !strings.Contains(message, "node-1") || !strings.Contains(message, "database locked") {
+		t.Fatalf("billing failure log = %q", message)
+	}
+}


### PR DESCRIPTION
## Summary
- add per-node traffic, time, and one-time startup fee rates for live cost estimates
- persist the first successful Agent report as the billing anchor and prefill an empty expiry to the same day next month
- accumulate traffic with reset-safe counters and a 30-second write throttle
- backfill existing clients from `created_at` and mark the anchor as estimated
- keep internal counters server-managed while allowing administrators to correct the anchor

## Semantics
This is an estimate, not an immutable invoice ledger. Changing rates recalculates the displayed estimate. The startup fee is included once after the first successful report; empty rates are zero. Traffic is measured in TiB and time in hours.

## Admin UI
The matching management form is proposed in komari-monitor/komari-web#82.

## Validation
- `go test ./database/clients`
- `go vet ./database/clients ./pkg/migrations`
- command-package build reaches the existing generated `web/public/defaultTheme` artifact requirement
- full SQLite migration tests remain dependent on a CGO-enabled CI runner