### PR TITLE
feat: use Glassmorphism as embedded default theme

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -1,13 +1,16 @@
 name: Build frontend theme
-description: Clone komari-web, build the default theme, and optionally upload it as an artifact.
+description: Build Komari Glassmorphism as the embedded default theme and optionally upload it as an artifact.
 
 inputs:
-  node-version:
-    description: Node.js version used to build komari-web.
-    default: "23"
+  bun-version:
+    description: Bun version used to build the theme.
+    default: "1.3.14"
   repository:
-    description: komari-web repository URL.
-    default: https://github.com/komari-monitor/komari-web
+    description: Glassmorphism theme repository URL.
+    default: https://github.com/sanrokamlan-prog/komari-theme-Glassmorphism
+  theme-ref:
+    description: Immutable theme tag or commit to embed.
+    default: v3.1.9
   artifact-name:
     description: Optional artifact name for the packed frontend theme.
     default: ""
@@ -15,30 +18,38 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
       with:
-        node-version: ${{ inputs.node-version }}
+        bun-version: ${{ inputs.bun-version }}
 
     - name: Clone and build frontend
       shell: bash
       run: |
         set -euxo pipefail
-        rm -rf komari-web
-        git clone --depth=1 "${{ inputs.repository }}" komari-web
-        cd komari-web
-        npm install
-        npm run build
+        rm -rf komari-theme
+        git clone --depth=1 --branch "${{ inputs.theme-ref }}" "${{ inputs.repository }}" komari-theme
+        cd komari-theme
+        bun install --frozen-lockfile
+        bun run build
         cd ..
 
         mkdir -p web/public/defaultTheme/dist
         rm -rf web/public/defaultTheme/dist/*
-        cp -r komari-web/dist/* web/public/defaultTheme/dist/
-        cp -f komari-web/komari-theme.json web/public/defaultTheme/
-        if [ -f komari-web/preview.png ]; then cp -f komari-web/preview.png web/public/defaultTheme/; fi
-        if [ -f komari-web/perview.png ]; then cp -f komari-web/perview.png web/public/defaultTheme/; fi
+        cp -r komari-theme/dist/* web/public/defaultTheme/dist/
+        cp -f komari-theme/komari-theme.json web/public/defaultTheme/
+        cp -f komari-theme/docs/preview.png web/public/defaultTheme/preview.png
+
+        # Embedded assets are always served from /themes/default, regardless of
+        # the source theme's installable short name.
+        jq '.short = "default"' web/public/defaultTheme/komari-theme.json > web/public/defaultTheme/komari-theme.json.tmp
+        mv web/public/defaultTheme/komari-theme.json.tmp web/public/defaultTheme/komari-theme.json
+
         if [ -f web/public/defaultTheme/preview.png ] && [ ! -f web/public/defaultTheme/perview.png ]; then cp -f web/public/defaultTheme/preview.png web/public/defaultTheme/perview.png; fi
         if [ -f web/public/defaultTheme/perview.png ] && [ ! -f web/public/defaultTheme/preview.png ]; then cp -f web/public/defaultTheme/perview.png web/public/defaultTheme/preview.png; fi
+
+        test -f web/public/defaultTheme/dist/index.html
+        test "$(jq -r '.short' web/public/defaultTheme/komari-theme.json)" = "default"
 
     - name: Pack frontend artifact
       if: ${{ inputs.artifact-name != '' }}

--- a/web/api/admin/theme.go
+++ b/web/api/admin/theme.go
@@ -76,6 +76,7 @@ func ListThemes(c *gin.Context) {
 		dt := models.Theme{}
 		err := json.Unmarshal(defaultTheme, &dt)
 		if err == nil {
+			dt = normalizeEmbeddedDefaultTheme(dt)
 			themes = append(themes, dt)
 		}
 
@@ -90,6 +91,11 @@ func ListThemes(c *gin.Context) {
 	}
 
 	api.RespondSuccess(c, themes)
+}
+
+func normalizeEmbeddedDefaultTheme(theme models.Theme) models.Theme {
+	theme.Short = public.DefaultTheme
+	return theme
 }
 
 // DeleteTheme 删除主题

--- a/web/api/admin/theme_test.go
+++ b/web/api/admin/theme_test.go
@@ -1,6 +1,25 @@
 package admin
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/komari-monitor/komari/database/models"
+)
+
+func TestNormalizeEmbeddedDefaultTheme(t *testing.T) {
+	theme := normalizeEmbeddedDefaultTheme(models.Theme{
+		Name:    "Komari Glassmorphism",
+		Short:   "Glassmorphism",
+		Version: "3.1.9",
+	})
+
+	if theme.Short != "default" {
+		t.Fatalf("normalizeEmbeddedDefaultTheme().Short = %q, want default", theme.Short)
+	}
+	if theme.Name != "Komari Glassmorphism" || theme.Version != "3.1.9" {
+		t.Fatalf("normalizeEmbeddedDefaultTheme() changed theme metadata: %#v", theme)
+	}
+}
 
 // TestIsValidThemeShort_PathTraversal 防止 DeleteTheme/UpdateTheme/SetTheme
 // 的路径穿越漏洞：req.Short 直接进入 filepath.Join("./data/theme", short)，


### PR DESCRIPTION
## Summary

- build Komari Glassmorphism v3.1.9 as the embedded default theme
- pin the theme ref and Bun version for reproducible frontend artifacts
- normalize embedded theme metadata to `short: default` so Theme Management uses `/themes/default`
- keep the complete `/admin`, `/terminal`, and `/manage/*` frontend bundled by the theme

This branch is based on upstream `main` and does not include the experimental billing changes from #604.

## Validation

- `go test ./web/api/admin`
- `go vet ./web/api/admin`
- Glassmorphism `bun run lint` and `bun run build`
- live integration on Komari `43547b9`: home, theme management, managed settings, admin, and terminal routes
- verified Theme Management no longer requests an uninstalled `/themes/Glassmorphism` path