### PR TITLE
fix(metricstore): avoid report counter series scan

### DIFF
--- a/database/metricstore/report.go
+++ b/database/metricstore/report.go
@@ -388,8 +388,28 @@ func latestReportCounter(ctx context.Context, s *metric.Store, metricName, entit
 
 	end := before.UTC().Add(-time.Nanosecond)
 	start := end.Add(-time.Duration(def.RetentionDays) * 24 * time.Hour)
+	// Query one point directly so the (metric_name, entity_id, ts_nano) index
+	// can satisfy both the filter and descending time order. Series with AggLast
+	// materializes the full retained range before selecting its final value.
+	points, err := s.Query(ctx, metric.Query{
+		MetricName: metricName,
+		EntityID:   entityID,
+		Start:      start,
+		End:        end,
+		Limit:      1,
+		Order:      metric.OrderDesc,
+	})
+	if err != nil {
+		return 0, false, err
+	}
+	if len(points) > 0 {
+		return int64(points[0].Value), true, nil
+	}
+
+	// Compaction may have moved all retained raw points into rollups. In that
+	// case, fall back to Series so restoring a report baseline remains correct.
 	interval := s.CompatibleSeriesInterval(start, before, 24*time.Hour)
-	points, err := s.Series(ctx, metric.AggregateQuery{
+	series, err := s.Series(ctx, metric.AggregateQuery{
 		Query: metric.Query{
 			MetricName: metricName,
 			EntityID:   entityID,
@@ -404,10 +424,10 @@ func latestReportCounter(ctx context.Context, s *metric.Store, metricName, entit
 	if err != nil {
 		return 0, false, err
 	}
-	if len(points) == 0 {
+	if len(series) == 0 {
 		return 0, false, nil
 	}
-	return int64(points[len(points)-1].Value), true, nil
+	return int64(series[len(series)-1].Value), true, nil
 }
 
 // GetLatestTrafficBefore returns the latest retained upload/download counters

--- a/database/metricstore/report_test.go
+++ b/database/metricstore/report_test.go
@@ -118,6 +118,40 @@ func TestWriteReportStoresRawMetricsAndResetAwareTraffic(t *testing.T) {
 	assertMetricValues(t, s, MetricTrafficDown, report.UUID, now.Add(-time.Second), now.Add(time.Second), []float64{20})
 }
 
+func TestLatestReportCounterUsesLatestRawPointBeforeBoundary(t *testing.T) {
+	ctx := context.Background()
+	s := useReportTestStore(t, nil)
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	const pointCount = 4096
+	points := make([]metric.Point, 0, pointCount*2)
+	for i := range pointCount {
+		timestamp := base.Add(time.Duration(i) * time.Second)
+		points = append(points,
+			metric.Point{MetricName: MetricNetTotalUp, EntityID: "historic-node", Timestamp: timestamp, Value: float64(i)},
+			metric.Point{MetricName: MetricNetTotalDown, EntityID: "historic-node", Timestamp: timestamp, Value: float64(i * 2)},
+		)
+	}
+	if err := s.WriteBatch(ctx, points); err != nil {
+		t.Fatalf("write historical counter points: %v", err)
+	}
+
+	before := base.Add(2048 * time.Second)
+	up, hasUp, err := latestReportCounter(ctx, s, MetricNetTotalUp, "historic-node", before)
+	if err != nil {
+		t.Fatalf("load latest upload counter: %v", err)
+	}
+	if !hasUp || up != 2047 {
+		t.Fatalf("upload counter = (%d, %t), want (2047, true)", up, hasUp)
+	}
+	down, hasDown, err := latestReportCounter(ctx, s, MetricNetTotalDown, "historic-node", before)
+	if err != nil {
+		t.Fatalf("load latest download counter: %v", err)
+	}
+	if !hasDown || down != 4094 {
+		t.Fatalf("download counter = (%d, %t), want (4094, true)", down, hasDown)
+	}
+}
+
 func TestReportBatcherFlushesQueuedReports(t *testing.T) {
 	ctx := context.Background()
 	s := useReportTestStore(t, nil)


### PR DESCRIPTION
# fix(metricstore): avoid report counter series scan

## Summary

Metric report batches could time out because initializing a counter baseline materialized the entire retained series before selecting its final value. This changes the raw-data path to fetch one pre-boundary point in descending timestamp order, allowing the `(metric_name, entity_id, ts_nano)` index to satisfy the lookup. The existing rollup-aware series path remains as a fallback after compaction has removed raw points.

Fixes #609

## Changes

- Query the latest retained raw upload/download counter directly with `ORDER BY ts_nano DESC LIMIT 1`.
- Preserve rollup-based counter restoration when no raw point is retained.
- Add coverage for both counters over a historical raw-point set and a strict timestamp boundary.

## Testing

- `sandbox-run "rm -rf /tmp/go125 && mkdir /tmp/go125 && curl -fsSLO https://go.dev/dl/go1.25.1.linux-arm64.tar.gz && tar -C /tmp/go125 -xzf go1.25.1.linux-arm64.tar.gz && GOROOT=/tmp/go125/go /tmp/go125/go/bin/gofmt -w database/metricstore/report.go database/metricstore/report_test.go && GOROOT=/tmp/go125/go /tmp/go125/go/bin/go test ./database/metricstore"` — passed.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
