### PR TITLE
feat(admin): 备份恢复改为分块上传

### DIFF
--- a/database/dbcore/dbcore.go
+++ b/database/dbcore/dbcore.go
@@ -207,7 +207,7 @@ func resolveDatabaseFile() string {
 }
 
 // backupOnVersionUpgrade 在检测到版本升级时，把当前 ./data 打包到
-// ./backup/upgrade-{time}.zip，便于升级（含 metrics 迁移）异常时回滚。
+// ./data/backup/upgrade-{time}.zip，便于升级（含 metrics 迁移）异常时回滚。
 //
 // 版本标识存放于配置库（configs 表，键 system_version），因此本函数必须在
 // config.SetDb 之后、一次性 metrics 迁移（InitStores）之前调用。
@@ -247,14 +247,15 @@ func backupOnVersionUpgrade() {
 		instance.Exec("PRAGMA wal_checkpoint(TRUNCATE);")
 	}
 
-	if err := os.MkdirAll("./backup", 0755); err != nil {
+	backupDir := filepath.Join(".", "data", "backup")
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
 		logger.Errorf("dbcore", "[upgrade-backup] failed to create backup dir: %v", err)
 		return
 	}
 	tsName := time.Now().UTC().Format("20060102-150405")
-	bakPath := filepath.Join("./backup", fmt.Sprintf("upgrade-%s.zip", tsName))
+	bakPath := filepath.Join(backupDir, fmt.Sprintf("upgrade-%s.zip", tsName))
 	backupZipPath := filepath.Join(".", "data", "backup.zip")
-	if zipErr := zipDirectoryExcluding("./data", bakPath, map[string]struct{}{backupZipPath: {}}); zipErr != nil {
+	if zipErr := zipDirectoryExcluding("./data", bakPath, map[string]struct{}{backupZipPath: {}, backupDir: {}}); zipErr != nil {
 		logger.Errorf("dbcore", "[upgrade-backup] failed to backup ./data before upgrade (from %q to %q): %v", prevVersion, versionID, zipErr)
 		return
 	}
@@ -344,21 +345,22 @@ func doInitialize() error {
 	func() {
 		backupZipPath := filepath.Join(".", "data", "backup.zip")
 		if _, statErr := os.Stat(backupZipPath); statErr == nil {
-			// 4. 把除了 ./data/backup.zip 之外的所有文件压缩到 ./backup/{time}.zip
-			if err := os.MkdirAll("./backup", 0755); err != nil {
+			// 4. 将当前数据快照保存到 ./data/backup/，并保留已有归档。
+			backupDir := filepath.Join(".", "data", "backup")
+			if err := os.MkdirAll(backupDir, 0755); err != nil {
 				logger.Errorf("dbcore", "[restore] failed to create backup dir: %v", err)
 			} else {
 				tsName := time.Now().UTC().Format("20060102-150405")
-				bakPath := filepath.Join("./backup", fmt.Sprintf("%s.zip", tsName))
-				if zipErr := zipDirectoryExcluding("./data", bakPath, map[string]struct{}{backupZipPath: {}}); zipErr != nil {
+				bakPath := filepath.Join(backupDir, fmt.Sprintf("pre-restore-%s.zip", tsName))
+				if zipErr := zipDirectoryExcluding("./data", bakPath, map[string]struct{}{backupZipPath: {}, backupDir: {}}); zipErr != nil {
 					logger.Errorf("dbcore", "[restore] failed to zip current data: %v", zipErr)
 				} else {
 					logger.Infof("dbcore", "[restore] current data zipped to %s", bakPath)
 				}
 			}
 
-			// 5. 删除除了 ./data/backup.zip 之外的所有文件
-			if delErr := removeAllInDirExcept("./data", map[string]struct{}{backupZipPath: {}}); delErr != nil {
+			// 5. 删除数据文件，但保留归档目录和待恢复的 backup.zip。
+			if delErr := removeAllInDirExcept("./data", map[string]struct{}{backupZipPath: {}, backupDir: {}}); delErr != nil {
 				logger.Errorf("dbcore", "[restore] failed to cleanup data dir: %v", delErr)
 			}
 

--- a/web/api/admin/backup_chunk_upload_test.go
+++ b/web/api/admin/backup_chunk_upload_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -98,5 +99,17 @@ func TestChunkUploadMetadataAndSize(t *testing.T) {
 	}
 	if gotSize != 7 {
 		t.Fatalf("chunk upload size = %d, want 7", gotSize)
+	}
+}
+
+func TestMergeChunksStopsWhenRequestIsCancelled(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "0.part"), []byte("chunk"), 0600); err != nil {
+		t.Fatalf("write chunk: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := mergeChunks(ctx, dir, filepath.Join(dir, "merged.zip")); err != context.Canceled {
+		t.Fatalf("mergeChunks error = %v, want context.Canceled", err)
 	}
 }

--- a/web/api/admin/backup_chunk_upload_test.go
+++ b/web/api/admin/backup_chunk_upload_test.go
@@ -1,0 +1,70 @@
+package admin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIsValidUploadID(t *testing.T) {
+	valid := "0123456789abcdef0123456789abcdef"
+	for _, uploadID := range []string{valid, "../" + valid, "", "not-a-valid-upload-id", valid + "00"} {
+		want := uploadID == valid
+		if got := isValidUploadID(uploadID); got != want {
+			t.Errorf("isValidUploadID(%q) = %v, want %v", uploadID, got, want)
+		}
+	}
+}
+
+func TestChunkUploadDirRejectsTraversal(t *testing.T) {
+	if _, err := chunkUploadDir(".."); err == nil {
+		t.Fatal("chunkUploadDir accepted traversal upload_id")
+	}
+}
+
+func TestCleanupExpiredChunkUploadsPreservesActiveUploads(t *testing.T) {
+	root := t.TempDir()
+	oldDir := filepath.Join(root, "old")
+	activeDir := filepath.Join(root, "active")
+	for _, dir := range []string{oldDir, activeDir} {
+		if err := os.Mkdir(dir, 0755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+	now := time.Now()
+	oldTime := now.Add(-uploadExpiration - time.Minute)
+	if err := os.Chtimes(oldDir, oldTime, oldTime); err != nil {
+		t.Fatalf("age old upload: %v", err)
+	}
+
+	if err := cleanupExpiredChunkUploads(root, now); err != nil {
+		t.Fatalf("cleanupExpiredChunkUploads: %v", err)
+	}
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("expired upload still exists: %v", err)
+	}
+	if _, err := os.Stat(activeDir); err != nil {
+		t.Fatalf("active upload was removed: %v", err)
+	}
+}
+
+func TestCopyWhitelistedFilesIncludesFont(t *testing.T) {
+	dataDir := t.TempDir()
+	backupDir := t.TempDir()
+	fontPath := filepath.Join(dataDir, "font.ttf")
+	if err := os.WriteFile(fontPath, []byte("font-data"), 0644); err != nil {
+		t.Fatalf("write font: %v", err)
+	}
+
+	if err := copyWhitelistedFilesFrom(dataDir, backupDir); err != nil {
+		t.Fatalf("copyWhitelistedFilesFrom: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(backupDir, "font.ttf"))
+	if err != nil {
+		t.Fatalf("read copied font: %v", err)
+	}
+	if string(content) != "font-data" {
+		t.Fatalf("font content = %q, want %q", content, "font-data")
+	}
+}

--- a/web/api/admin/backup_chunk_upload_test.go
+++ b/web/api/admin/backup_chunk_upload_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -66,5 +67,36 @@ func TestCopyWhitelistedFilesIncludesFont(t *testing.T) {
 	}
 	if string(content) != "font-data" {
 		t.Fatalf("font content = %q, want %q", content, "font-data")
+	}
+}
+
+func TestChunkUploadMetadataAndSize(t *testing.T) {
+	dir := t.TempDir()
+	metadata, err := json.Marshal(chunkUploadMetadata{Size: 7})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, uploadMetadataName), metadata, 0600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	for name, content := range map[string]string{"0.part": "abc", "1.part": "defg", "ignored.txt": "ignored"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	gotMetadata, err := readChunkUploadMetadata(dir)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	if gotMetadata.Size != 7 {
+		t.Fatalf("metadata size = %d, want 7", gotMetadata.Size)
+	}
+	gotSize, err := chunkUploadSize(dir)
+	if err != nil {
+		t.Fatalf("chunkUploadSize: %v", err)
+	}
+	if gotSize != 7 {
+		t.Fatalf("chunk upload size = %d, want 7", gotSize)
 	}
 }

--- a/web/api/admin/backup_chunk_upload_test.go
+++ b/web/api/admin/backup_chunk_upload_test.go
@@ -1,18 +1,15 @@
 package admin
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 func TestIsValidUploadID(t *testing.T) {
-	valid := "0123456789abcdef0123456789abcdef"
-	for _, uploadID := range []string{valid, "../" + valid, "", "not-a-valid-upload-id", valid + "00"} {
-		want := uploadID == valid
+	for _, uploadID := range []string{chunkUploadID, "../backup", "", "another-upload"} {
+		want := uploadID == chunkUploadID
 		if got := isValidUploadID(uploadID); got != want {
 			t.Errorf("isValidUploadID(%q) = %v, want %v", uploadID, got, want)
 		}
@@ -25,29 +22,20 @@ func TestChunkUploadDirRejectsTraversal(t *testing.T) {
 	}
 }
 
-func TestCleanupExpiredChunkUploadsPreservesActiveUploads(t *testing.T) {
+func TestClearChunkUploadCache(t *testing.T) {
 	root := t.TempDir()
-	oldDir := filepath.Join(root, "old")
-	activeDir := filepath.Join(root, "active")
-	for _, dir := range []string{oldDir, activeDir} {
-		if err := os.Mkdir(dir, 0755); err != nil {
-			t.Fatalf("create %s: %v", dir, err)
-		}
+	if err := os.WriteFile(filepath.Join(root, "interrupted.part"), []byte("stale"), 0600); err != nil {
+		t.Fatalf("write cache: %v", err)
 	}
-	now := time.Now()
-	oldTime := now.Add(-uploadExpiration - time.Minute)
-	if err := os.Chtimes(oldDir, oldTime, oldTime); err != nil {
-		t.Fatalf("age old upload: %v", err)
+	if err := clearChunkUploadCache(root); err != nil {
+		t.Fatalf("clearChunkUploadCache: %v", err)
 	}
-
-	if err := cleanupExpiredChunkUploads(root, now); err != nil {
-		t.Fatalf("cleanupExpiredChunkUploads: %v", err)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
 	}
-	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
-		t.Fatalf("expired upload still exists: %v", err)
-	}
-	if _, err := os.Stat(activeDir); err != nil {
-		t.Fatalf("active upload was removed: %v", err)
+	if len(entries) != 0 {
+		t.Fatalf("cache entries = %d, want 0", len(entries))
 	}
 }
 
@@ -99,17 +87,5 @@ func TestChunkUploadMetadataAndSize(t *testing.T) {
 	}
 	if gotSize != 7 {
 		t.Fatalf("chunk upload size = %d, want 7", gotSize)
-	}
-}
-
-func TestMergeChunksStopsWhenRequestIsCancelled(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "0.part"), []byte("chunk"), 0600); err != nil {
-		t.Fatalf("write chunk: %v", err)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	if err := mergeChunks(ctx, dir, filepath.Join(dir, "merged.zip")); err != context.Canceled {
-		t.Fatalf("mergeChunks error = %v, want context.Canceled", err)
 	}
 }

--- a/web/api/admin/backup_whitelist.go
+++ b/web/api/admin/backup_whitelist.go
@@ -1,0 +1,64 @@
+package admin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// backupWhitelist 定义需要备份的 ./data/ 下文件/目录（相对路径）。
+// 目录项会递归包含其下所有文件。新增需持久化数据时在此追加。
+//
+// 注意：komari.db 不在白名单中——database 通过 DownloadBackup 中的
+// SQLite VACUUM INTO 或 copyFile 单独备份，确保一致性快照。
+var backupWhitelist = []string{
+	"favicon.ico",
+	"theme/",
+	"metrics.db",
+}
+
+// copyWhitelistedFiles 将白名单中存在的文件/目录复制到临时目录。
+// 不存在的项静默跳过，确保白名单扩展的向前兼容。
+func copyWhitelistedFiles(tempDir string) error {
+	for _, relPath := range backupWhitelist {
+		src := filepath.Join(".", "data", relPath)
+		info, err := os.Stat(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("stat whitelist entry %s: %v", relPath, err)
+		}
+		if info.IsDir() {
+			if err := copyDir(src, filepath.Join(tempDir, relPath)); err != nil {
+				return fmt.Errorf("copy whitelist dir %s: %v", relPath, err)
+			}
+		} else {
+			if err := copyFile(src, filepath.Join(tempDir, relPath)); err != nil {
+				return fmt.Errorf("copy whitelist file %s: %v", relPath, err)
+			}
+		}
+	}
+	return nil
+}
+
+// copyDir 递归复制目录到目标路径。
+func copyDir(srcDir, dstDir string) error {
+	return filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		dst := filepath.Join(dstDir, rel)
+		if info.IsDir() {
+			return os.MkdirAll(dst, 0755)
+		}
+		return copyFile(path, dst)
+	})
+}

--- a/web/api/admin/backup_whitelist.go
+++ b/web/api/admin/backup_whitelist.go
@@ -13,6 +13,7 @@ import (
 // SQLite VACUUM INTO 或 copyFile 单独备份，确保一致性快照。
 var backupWhitelist = []string{
 	"favicon.ico",
+	"font.ttf",
 	"theme/",
 	"metrics.db",
 }
@@ -20,8 +21,12 @@ var backupWhitelist = []string{
 // copyWhitelistedFiles 将白名单中存在的文件/目录复制到临时目录。
 // 不存在的项静默跳过，确保白名单扩展的向前兼容。
 func copyWhitelistedFiles(tempDir string) error {
+	return copyWhitelistedFilesFrom(filepath.Join(".", "data"), tempDir)
+}
+
+func copyWhitelistedFilesFrom(dataDir, tempDir string) error {
 	for _, relPath := range backupWhitelist {
-		src := filepath.Join(".", "data", relPath)
+		src := filepath.Join(dataDir, relPath)
 		info, err := os.Stat(src)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/web/api/admin/chunk_upload.go
+++ b/web/api/admin/chunk_upload.go
@@ -1,0 +1,262 @@
+package admin
+
+import (
+	"archive/zip"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/komari-monitor/komari/web/api"
+)
+
+const defaultChunkSize = 5 * 1024 * 1024 // 5MB
+
+// generateUploadID 生成随机上传 ID，仅包含 hex 字符防止路径穿越。
+func generateUploadID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// InitChunkUpload 初始化分块上传，返回 upload_id 和 chunk_size。
+// 每次初始化前清理上一次遗留的 .uploading/ 临时目录。
+func InitChunkUpload(c *gin.Context) {
+	// 清理上次可能残留的临时目录
+	uploadingRoot := filepath.Join(".", "data", "backup", ".uploading")
+	_ = os.RemoveAll(uploadingRoot)
+
+	uploadID, err := generateUploadID()
+	if err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error generating upload ID: %v", err))
+		return
+	}
+
+	chunkDir := filepath.Join(".", "data", "backup", ".uploading", uploadID)
+	if err := os.MkdirAll(chunkDir, 0755); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating upload directory: %v", err))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"upload_id":  uploadID,
+		"chunk_size": defaultChunkSize,
+	})
+}
+
+// UploadChunk 接收单个分块，保存到临时目录。
+func UploadChunk(c *gin.Context) {
+	uploadID := c.PostForm("upload_id")
+	if uploadID == "" {
+		api.RespondError(c, http.StatusBadRequest, "upload_id is required")
+		return
+	}
+
+	chunkIndexStr := c.PostForm("chunk_index")
+	if chunkIndexStr == "" {
+		api.RespondError(c, http.StatusBadRequest, "chunk_index is required")
+		return
+	}
+	chunkIndex, err := strconv.Atoi(chunkIndexStr)
+	if err != nil || chunkIndex < 0 {
+		api.RespondError(c, http.StatusBadRequest, "chunk_index must be a non-negative integer")
+		return
+	}
+
+	chunkDir := filepath.Join(".", "data", "backup", ".uploading", uploadID)
+	if _, err := os.Stat(chunkDir); err != nil {
+		api.RespondError(c, http.StatusNotFound, "upload_id not found or expired")
+		return
+	}
+
+	file, header, err := c.Request.FormFile("chunk_data")
+	if err != nil {
+		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Error getting chunk data: %v", err))
+		return
+	}
+	defer file.Close()
+
+	if header.Size > defaultChunkSize+1024 {
+		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Chunk too large: %d bytes (max %d)", header.Size, defaultChunkSize))
+		return
+	}
+
+	chunkPath := filepath.Join(chunkDir, fmt.Sprintf("%d.part", chunkIndex))
+	out, err := os.Create(chunkPath)
+	if err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error saving chunk: %v", err))
+		return
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, file); err != nil {
+		os.Remove(chunkPath)
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error writing chunk: %v", err))
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"received":    true,
+		"chunk_index": chunkIndex,
+	})
+}
+
+// MergeChunkUpload 合并分块 → 校验 ZIP → 保存到 data/backup/ → 触发恢复。
+func MergeChunkUpload(c *gin.Context) {
+	// 尝试获取恢复锁
+	if !restoreMutex.TryLock() {
+		api.RespondError(c, http.StatusConflict, "Another restore operation is already in progress")
+		return
+	}
+	defer restoreMutex.Unlock()
+
+	var req struct {
+		UploadID string `json:"upload_id" binding:"required"`
+		Filename string `json:"filename"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Invalid request: %v", err))
+		return
+	}
+
+	chunkDir := filepath.Join(".", "data", "backup", ".uploading", req.UploadID)
+	if _, err := os.Stat(chunkDir); err != nil {
+		api.RespondError(c, http.StatusNotFound, "upload_id not found or expired")
+		return
+	}
+
+	backupDir := filepath.Join(".", "data", "backup")
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating backup directory: %v", err))
+		return
+	}
+
+	// 生成归档文件名
+	filename := req.Filename
+	if filename == "" {
+		filename = fmt.Sprintf("backup-%s.zip", time.Now().UTC().Format("20060102-150405"))
+	} else if !strings.HasSuffix(strings.ToLower(filename), ".zip") {
+		filename += ".zip"
+	}
+
+	mergedPath := filepath.Join(chunkDir, "merged.zip")
+	if err := mergeChunks(chunkDir, mergedPath); err != nil {
+		cleanupChunkDir(chunkDir)
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error merging chunks: %v", err))
+		return
+	}
+
+	if err := validateBackupZip(mergedPath); err != nil {
+		cleanupChunkDir(chunkDir)
+		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Invalid backup: %v", err))
+		return
+	}
+
+	// 保存归档副本到 data/backup/{filename}
+	archivePath := filepath.Join(backupDir, filename)
+	if err := os.Rename(mergedPath, archivePath); err != nil {
+		if cpErr := copyFile(mergedPath, archivePath); cpErr != nil {
+			cleanupChunkDir(chunkDir)
+			api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error saving merged file: %v", cpErr))
+			return
+		}
+	}
+
+	// 裁剪旧备份，仅保留最近 3 份
+	pruneOldZipByPrefix(backupDir, "backup-", 3)
+
+	// 写入 ./data/backup.zip 作为恢复标记
+	// 注意：pre-restore 备份由 dbcore.doInitialize 在恢复执行时创建，上传阶段不重复创建。
+	restorePath := filepath.Join(".", "data", "backup.zip")
+	_ = os.Remove(restorePath)
+	if err := copyFile(archivePath, restorePath); err != nil {
+		cleanupChunkDir(chunkDir)
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error preparing restore: %v", err))
+		return
+	}
+
+	cleanupChunkDir(chunkDir)
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":  "success",
+		"message": "Backup uploaded successfully. The service will restart and apply the backup.",
+		"path":    restorePath,
+	})
+
+	go func() {
+		log.Println("Backup uploaded (chunk), restarting service in 2 seconds to apply on startup...")
+		time.Sleep(2 * time.Second)
+		os.Exit(0)
+	}()
+}
+
+// mergeChunks 按分块索引数值排序后顺序合并所有 .part 文件。
+func mergeChunks(chunkDir, destPath string) error {
+	parts, err := filepath.Glob(filepath.Join(chunkDir, "*.part"))
+	if err != nil {
+		return err
+	}
+	if len(parts) == 0 {
+		return fmt.Errorf("no chunks found")
+	}
+
+	// 按分块索引数值排序（非字典序），避免 10.part 排在 2.part 前面
+	sort.Slice(parts, func(i, j int) bool {
+		idxI, _ := strconv.Atoi(strings.TrimSuffix(filepath.Base(parts[i]), ".part"))
+		idxJ, _ := strconv.Atoi(strings.TrimSuffix(filepath.Base(parts[j]), ".part"))
+		return idxI < idxJ
+	})
+
+	out, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	for _, partPath := range parts {
+		f, err := os.Open(partPath)
+		if err != nil {
+			return fmt.Errorf("error opening chunk %s: %v", filepath.Base(partPath), err)
+		}
+		if _, err := io.Copy(out, f); err != nil {
+			f.Close()
+			return fmt.Errorf("error reading chunk %s: %v", filepath.Base(partPath), err)
+		}
+		f.Close()
+	}
+	return nil
+}
+
+// validateBackupZip 校验 ZIP 结构完整性及 komari-backup-markup 标记文件。
+func validateBackupZip(zipPath string) error {
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("not a valid zip file: %v", err)
+	}
+	defer zr.Close()
+
+	for _, f := range zr.File {
+		if f.Name == "komari-backup-markup" {
+			return nil
+		}
+	}
+	return fmt.Errorf("missing komari-backup-markup file")
+}
+
+// cleanupChunkDir 清理临时上传目录。
+func cleanupChunkDir(chunkDir string) {
+	if err := os.RemoveAll(chunkDir); err != nil {
+		log.Printf("[chunk_upload] failed to cleanup %s: %v", chunkDir, err)
+	}
+}

--- a/web/api/admin/chunk_upload.go
+++ b/web/api/admin/chunk_upload.go
@@ -17,9 +17,18 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/komari-monitor/komari/web/api"
+	"github.com/komari-monitor/komari/web/backup"
 )
 
-const defaultChunkSize = 5 * 1024 * 1024 // 5MB
+const (
+	defaultChunkSize    = 5 * 1024 * 1024 // 5 MiB
+	maxChunkRequestSize = defaultChunkSize + 1*1024*1024
+	uploadIDLength      = 32
+	uploadExpiration    = 24 * time.Hour
+	maxChunkIndex       = 1_000_000
+)
+
+var chunkUploadRoot = filepath.Join(".", "data", "backup", ".uploading")
 
 // generateUploadID 生成随机上传 ID，仅包含 hex 字符防止路径穿越。
 func generateUploadID() (string, error) {
@@ -30,12 +39,50 @@ func generateUploadID() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
+func isValidUploadID(uploadID string) bool {
+	if len(uploadID) != uploadIDLength {
+		return false
+	}
+	_, err := hex.DecodeString(uploadID)
+	return err == nil
+}
+
+func chunkUploadDir(uploadID string) (string, error) {
+	if !isValidUploadID(uploadID) {
+		return "", fmt.Errorf("invalid upload_id")
+	}
+	return filepath.Join(chunkUploadRoot, uploadID), nil
+}
+
+func cleanupExpiredChunkUploads(root string, now time.Time) error {
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || now.Sub(info.ModTime()) < uploadExpiration {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(root, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // InitChunkUpload 初始化分块上传，返回 upload_id 和 chunk_size。
-// 每次初始化前清理上一次遗留的 .uploading/ 临时目录。
+// 仅清理过期上传，避免影响仍在进行的其他上传。
 func InitChunkUpload(c *gin.Context) {
-	// 清理上次可能残留的临时目录
-	uploadingRoot := filepath.Join(".", "data", "backup", ".uploading")
-	_ = os.RemoveAll(uploadingRoot)
+	if err := cleanupExpiredChunkUploads(chunkUploadRoot, time.Now()); err != nil {
+		log.Printf("[chunk_upload] failed to clean expired uploads: %v", err)
+	}
 
 	uploadID, err := generateUploadID()
 	if err != nil {
@@ -43,7 +90,11 @@ func InitChunkUpload(c *gin.Context) {
 		return
 	}
 
-	chunkDir := filepath.Join(".", "data", "backup", ".uploading", uploadID)
+	chunkDir, err := chunkUploadDir(uploadID)
+	if err != nil {
+		api.RespondError(c, http.StatusInternalServerError, "Error preparing upload directory")
+		return
+	}
 	if err := os.MkdirAll(chunkDir, 0755); err != nil {
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating upload directory: %v", err))
 		return
@@ -57,9 +108,11 @@ func InitChunkUpload(c *gin.Context) {
 
 // UploadChunk 接收单个分块，保存到临时目录。
 func UploadChunk(c *gin.Context) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxChunkRequestSize)
 	uploadID := c.PostForm("upload_id")
-	if uploadID == "" {
-		api.RespondError(c, http.StatusBadRequest, "upload_id is required")
+	chunkDir, err := chunkUploadDir(uploadID)
+	if err != nil {
+		api.RespondError(c, http.StatusBadRequest, "invalid upload_id")
 		return
 	}
 
@@ -69,28 +122,22 @@ func UploadChunk(c *gin.Context) {
 		return
 	}
 	chunkIndex, err := strconv.Atoi(chunkIndexStr)
-	if err != nil || chunkIndex < 0 {
+	if err != nil || chunkIndex < 0 || chunkIndex > maxChunkIndex {
 		api.RespondError(c, http.StatusBadRequest, "chunk_index must be a non-negative integer")
 		return
 	}
 
-	chunkDir := filepath.Join(".", "data", "backup", ".uploading", uploadID)
-	if _, err := os.Stat(chunkDir); err != nil {
+	if info, err := os.Stat(chunkDir); err != nil || !info.IsDir() {
 		api.RespondError(c, http.StatusNotFound, "upload_id not found or expired")
 		return
 	}
 
-	file, header, err := c.Request.FormFile("chunk_data")
+	file, _, err := c.Request.FormFile("chunk_data")
 	if err != nil {
 		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Error getting chunk data: %v", err))
 		return
 	}
 	defer file.Close()
-
-	if header.Size > defaultChunkSize+1024 {
-		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Chunk too large: %d bytes (max %d)", header.Size, defaultChunkSize))
-		return
-	}
 
 	chunkPath := filepath.Join(chunkDir, fmt.Sprintf("%d.part", chunkIndex))
 	out, err := os.Create(chunkPath)
@@ -98,11 +145,18 @@ func UploadChunk(c *gin.Context) {
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error saving chunk: %v", err))
 		return
 	}
-	defer out.Close()
 
-	if _, err := io.Copy(out, file); err != nil {
+	written, err := io.Copy(out, io.LimitReader(file, defaultChunkSize+1))
+	if closeErr := out.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil || written > defaultChunkSize {
 		os.Remove(chunkPath)
-		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error writing chunk: %v", err))
+		if err != nil {
+			api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error writing chunk: %v", err))
+		} else {
+			api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Chunk too large: %d bytes (max %d)", written, defaultChunkSize))
+		}
 		return
 	}
 
@@ -114,24 +168,20 @@ func UploadChunk(c *gin.Context) {
 
 // MergeChunkUpload 合并分块 → 校验 ZIP → 保存到 data/backup/ → 触发恢复。
 func MergeChunkUpload(c *gin.Context) {
-	// 尝试获取恢复锁
-	if !restoreMutex.TryLock() {
-		api.RespondError(c, http.StatusConflict, "Another restore operation is already in progress")
-		return
-	}
-	defer restoreMutex.Unlock()
-
 	var req struct {
 		UploadID string `json:"upload_id" binding:"required"`
-		Filename string `json:"filename"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Invalid request: %v", err))
 		return
 	}
 
-	chunkDir := filepath.Join(".", "data", "backup", ".uploading", req.UploadID)
-	if _, err := os.Stat(chunkDir); err != nil {
+	chunkDir, err := chunkUploadDir(req.UploadID)
+	if err != nil {
+		api.RespondError(c, http.StatusBadRequest, "invalid upload_id")
+		return
+	}
+	if info, err := os.Stat(chunkDir); err != nil || !info.IsDir() {
 		api.RespondError(c, http.StatusNotFound, "upload_id not found or expired")
 		return
 	}
@@ -142,13 +192,7 @@ func MergeChunkUpload(c *gin.Context) {
 		return
 	}
 
-	// 生成归档文件名
-	filename := req.Filename
-	if filename == "" {
-		filename = fmt.Sprintf("backup-%s.zip", time.Now().UTC().Format("20060102-150405"))
-	} else if !strings.HasSuffix(strings.ToLower(filename), ".zip") {
-		filename += ".zip"
-	}
+	archiveName := fmt.Sprintf("backup-%s.zip", time.Now().UTC().Format("20060102-150405.000000"))
 
 	mergedPath := filepath.Join(chunkDir, "merged.zip")
 	if err := mergeChunks(chunkDir, mergedPath); err != nil {
@@ -163,8 +207,8 @@ func MergeChunkUpload(c *gin.Context) {
 		return
 	}
 
-	// 保存归档副本到 data/backup/{filename}
-	archivePath := filepath.Join(backupDir, filename)
+	// 保存归档副本到 data/backup/，文件名由服务端生成。
+	archivePath := filepath.Join(backupDir, archiveName)
 	if err := os.Rename(mergedPath, archivePath); err != nil {
 		if cpErr := copyFile(mergedPath, archivePath); cpErr != nil {
 			cleanupChunkDir(chunkDir)
@@ -176,13 +220,16 @@ func MergeChunkUpload(c *gin.Context) {
 	// 裁剪旧备份，仅保留最近 3 份
 	pruneOldZipByPrefix(backupDir, "backup-", 3)
 
-	// 写入 ./data/backup.zip 作为恢复标记
-	// 注意：pre-restore 备份由 dbcore.doInitialize 在恢复执行时创建，上传阶段不重复创建。
-	restorePath := filepath.Join(".", "data", "backup.zip")
-	_ = os.Remove(restorePath)
-	if err := copyFile(archivePath, restorePath); err != nil {
+	archive, err := os.Open(archivePath)
+	if err != nil {
 		cleanupChunkDir(chunkDir)
-		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error preparing restore: %v", err))
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error opening archived backup: %v", err))
+		return
+	}
+	defer archive.Close()
+	if err := backup.SaveUploadedBackup(archive, archiveName); err != nil {
+		cleanupChunkDir(chunkDir)
+		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Error preparing restore: %v", err))
 		return
 	}
 
@@ -191,7 +238,7 @@ func MergeChunkUpload(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"status":  "success",
 		"message": "Backup uploaded successfully. The service will restart and apply the backup.",
-		"path":    restorePath,
+		"path":    filepath.Join(".", "data", "backup.zip"),
 	})
 
 	go func() {

--- a/web/api/admin/chunk_upload.go
+++ b/web/api/admin/chunk_upload.go
@@ -1,9 +1,6 @@
 package admin
 
 import (
-	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,7 +11,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -25,15 +21,11 @@ import (
 const (
 	defaultChunkSize    = 5 * 1024 * 1024 // 5 MiB
 	maxChunkRequestSize = defaultChunkSize + 1*1024*1024
-	uploadIDLength      = 32
-	uploadExpiration    = 24 * time.Hour
+	chunkUploadID       = "backup"
 	maxChunkIndex       = int(backup.MaxArchiveSize / defaultChunkSize)
 )
 
-var (
-	chunkUploadRoot = filepath.Join(".", "data", "backup", ".uploading")
-	chunkUploadMu   sync.Mutex
-)
+var chunkUploadRoot = filepath.Join(".", "data", "backup", ".uploading")
 
 const uploadMetadataName = "upload.json"
 
@@ -41,21 +33,8 @@ type chunkUploadMetadata struct {
 	Size int64 `json:"size"`
 }
 
-// generateUploadID 生成随机上传 ID，仅包含 hex 字符防止路径穿越。
-func generateUploadID() (string, error) {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(b), nil
-}
-
 func isValidUploadID(uploadID string) bool {
-	if len(uploadID) != uploadIDLength {
-		return false
-	}
-	_, err := hex.DecodeString(uploadID)
-	return err == nil
+	return uploadID == chunkUploadID
 }
 
 func chunkUploadDir(uploadID string) (string, error) {
@@ -102,36 +81,16 @@ func chunkUploadSize(chunkDir string) (int64, error) {
 	return total, nil
 }
 
-func cleanupExpiredChunkUploads(root string, now time.Time) error {
-	entries, err := os.ReadDir(root)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
+func clearChunkUploadCache(root string) error {
+	if err := os.RemoveAll(root); err != nil {
 		return err
 	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		info, err := entry.Info()
-		if err != nil || now.Sub(info.ModTime()) < uploadExpiration {
-			continue
-		}
-		if err := os.RemoveAll(filepath.Join(root, entry.Name())); err != nil {
-			return err
-		}
-	}
-	return nil
+	return os.MkdirAll(root, 0755)
 }
 
 // InitChunkUpload 初始化分块上传，返回 upload_id 和 chunk_size。
-// 仅清理过期上传，避免影响仍在进行的其他上传。
+// Komari 使用单一上传槽位，初始化时会清除上次中断留下的全部缓存。
 func InitChunkUpload(c *gin.Context) {
-	if err := cleanupExpiredChunkUploads(chunkUploadRoot, time.Now()); err != nil {
-		log.Printf("[chunk_upload] failed to clean expired uploads: %v", err)
-	}
-
 	var req struct {
 		Size int64 `json:"size"`
 	}
@@ -140,13 +99,11 @@ func InitChunkUpload(c *gin.Context) {
 		return
 	}
 
-	uploadID, err := generateUploadID()
-	if err != nil {
-		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error generating upload ID: %v", err))
+	if err := clearChunkUploadCache(chunkUploadRoot); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error clearing upload cache: %v", err))
 		return
 	}
-
-	chunkDir, err := chunkUploadDir(uploadID)
+	chunkDir, err := chunkUploadDir(chunkUploadID)
 	if err != nil {
 		api.RespondError(c, http.StatusInternalServerError, "Error preparing upload directory")
 		return
@@ -157,18 +114,18 @@ func InitChunkUpload(c *gin.Context) {
 	}
 	metadata, err := json.Marshal(chunkUploadMetadata{Size: req.Size})
 	if err != nil {
-		cleanupChunkDir(chunkDir)
+		clearChunkUploadCache(chunkUploadRoot)
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error encoding upload metadata: %v", err))
 		return
 	}
 	if err := os.WriteFile(filepath.Join(chunkDir, uploadMetadataName), metadata, 0600); err != nil {
-		cleanupChunkDir(chunkDir)
+		clearChunkUploadCache(chunkUploadRoot)
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error writing upload metadata: %v", err))
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"upload_id":  uploadID,
+		"upload_id":  chunkUploadID,
 		"chunk_size": defaultChunkSize,
 	})
 }
@@ -206,8 +163,6 @@ func UploadChunk(c *gin.Context) {
 	}
 	defer file.Close()
 
-	chunkUploadMu.Lock()
-	defer chunkUploadMu.Unlock()
 	metadata, err := readChunkUploadMetadata(chunkDir)
 	if err != nil {
 		api.RespondError(c, http.StatusNotFound, "upload_id not found or expired")
@@ -297,8 +252,6 @@ func MergeChunkUpload(c *gin.Context) {
 		api.RespondError(c, http.StatusNotFound, "upload_id not found or expired")
 		return
 	}
-	chunkUploadMu.Lock()
-	defer chunkUploadMu.Unlock()
 	metadata, err := readChunkUploadMetadata(chunkDir)
 	if err != nil {
 		api.RespondError(c, http.StatusNotFound, "upload_id not found or expired")
@@ -322,26 +275,15 @@ func MergeChunkUpload(c *gin.Context) {
 	archiveName := fmt.Sprintf("backup-%s.zip", time.Now().UTC().Format("20060102-150405.000000"))
 
 	mergedPath := filepath.Join(chunkDir, "merged.zip")
-	if err := mergeChunks(c.Request.Context(), chunkDir, mergedPath); err != nil {
-		cleanupChunkDir(chunkDir)
-		if c.Request.Context().Err() != nil {
-			return
-		}
+	if err := mergeChunks(chunkDir, mergedPath); err != nil {
+		clearChunkUploadCache(chunkUploadRoot)
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error merging chunks: %v", err))
-		return
-	}
-	if c.Request.Context().Err() != nil {
-		cleanupChunkDir(chunkDir)
 		return
 	}
 
 	if err := validateBackupZip(mergedPath); err != nil {
-		cleanupChunkDir(chunkDir)
+		clearChunkUploadCache(chunkUploadRoot)
 		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Invalid backup: %v", err))
-		return
-	}
-	if c.Request.Context().Err() != nil {
-		cleanupChunkDir(chunkDir)
 		return
 	}
 
@@ -349,36 +291,26 @@ func MergeChunkUpload(c *gin.Context) {
 	archivePath := filepath.Join(backupDir, archiveName)
 	if err := os.Rename(mergedPath, archivePath); err != nil {
 		if cpErr := copyFile(mergedPath, archivePath); cpErr != nil {
-			cleanupChunkDir(chunkDir)
+			clearChunkUploadCache(chunkUploadRoot)
 			api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error saving merged file: %v", cpErr))
 			return
 		}
 	}
 
-	// 裁剪旧备份，仅保留最近 3 份
-	pruneOldZipByPrefix(backupDir, "backup-", 3)
-
 	archive, err := os.Open(archivePath)
 	if err != nil {
-		cleanupChunkDir(chunkDir)
+		clearChunkUploadCache(chunkUploadRoot)
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error opening archived backup: %v", err))
 		return
 	}
 	defer archive.Close()
 	if err := restoreLock.SaveUploadedBackup(archive, archiveName); err != nil {
-		cleanupChunkDir(chunkDir)
+		clearChunkUploadCache(chunkUploadRoot)
 		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Error preparing restore: %v", err))
 		return
 	}
-	if c.Request.Context().Err() != nil {
-		if err := os.Remove(filepath.Join(".", "data", "backup.zip")); err != nil && !os.IsNotExist(err) {
-			log.Printf("[chunk_upload] failed to discard cancelled restore: %v", err)
-		}
-		cleanupChunkDir(chunkDir)
-		return
-	}
 
-	cleanupChunkDir(chunkDir)
+	clearChunkUploadCache(chunkUploadRoot)
 
 	c.JSON(http.StatusOK, gin.H{
 		"status":  "success",
@@ -396,7 +328,7 @@ func MergeChunkUpload(c *gin.Context) {
 }
 
 // mergeChunks 按分块索引数值排序后顺序合并所有 .part 文件。
-func mergeChunks(ctx context.Context, chunkDir, destPath string) error {
+func mergeChunks(chunkDir, destPath string) error {
 	parts, err := filepath.Glob(filepath.Join(chunkDir, "*.part"))
 	if err != nil {
 		return err
@@ -419,9 +351,6 @@ func mergeChunks(ctx context.Context, chunkDir, destPath string) error {
 	defer out.Close()
 
 	for _, partPath := range parts {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
 		f, err := os.Open(partPath)
 		if err != nil {
 			return fmt.Errorf("error opening chunk %s: %v", filepath.Base(partPath), err)
@@ -441,11 +370,4 @@ func validateBackupZip(zipPath string) error {
 		return fmt.Errorf("not a valid backup archive: %w", err)
 	}
 	return nil
-}
-
-// cleanupChunkDir 清理临时上传目录。
-func cleanupChunkDir(chunkDir string) {
-	if err := os.RemoveAll(chunkDir); err != nil {
-		log.Printf("[chunk_upload] failed to cleanup %s: %v", chunkDir, err)
-	}
 }

--- a/web/api/admin/chunk_upload.go
+++ b/web/api/admin/chunk_upload.go
@@ -1,9 +1,9 @@
 package admin
 
 import (
-	"archive/zip"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -25,10 +26,19 @@ const (
 	maxChunkRequestSize = defaultChunkSize + 1*1024*1024
 	uploadIDLength      = 32
 	uploadExpiration    = 24 * time.Hour
-	maxChunkIndex       = 1_000_000
+	maxChunkIndex       = int(backup.MaxArchiveSize / defaultChunkSize)
 )
 
-var chunkUploadRoot = filepath.Join(".", "data", "backup", ".uploading")
+var (
+	chunkUploadRoot = filepath.Join(".", "data", "backup", ".uploading")
+	chunkUploadMu   sync.Mutex
+)
+
+const uploadMetadataName = "upload.json"
+
+type chunkUploadMetadata struct {
+	Size int64 `json:"size"`
+}
 
 // generateUploadID 生成随机上传 ID，仅包含 hex 字符防止路径穿越。
 func generateUploadID() (string, error) {
@@ -52,6 +62,43 @@ func chunkUploadDir(uploadID string) (string, error) {
 		return "", fmt.Errorf("invalid upload_id")
 	}
 	return filepath.Join(chunkUploadRoot, uploadID), nil
+}
+
+func readChunkUploadMetadata(chunkDir string) (chunkUploadMetadata, error) {
+	var metadata chunkUploadMetadata
+	data, err := os.ReadFile(filepath.Join(chunkDir, uploadMetadataName))
+	if err != nil {
+		return metadata, err
+	}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return metadata, err
+	}
+	if metadata.Size <= 0 || metadata.Size > backup.MaxArchiveSize {
+		return metadata, fmt.Errorf("invalid upload size")
+	}
+	return metadata, nil
+}
+
+func chunkUploadSize(chunkDir string) (int64, error) {
+	entries, err := os.ReadDir(chunkDir)
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".part") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return 0, err
+		}
+		if total > backup.MaxArchiveSize-info.Size() {
+			return 0, fmt.Errorf("uploaded chunks exceed the archive limit")
+		}
+		total += info.Size()
+	}
+	return total, nil
 }
 
 func cleanupExpiredChunkUploads(root string, now time.Time) error {
@@ -84,6 +131,14 @@ func InitChunkUpload(c *gin.Context) {
 		log.Printf("[chunk_upload] failed to clean expired uploads: %v", err)
 	}
 
+	var req struct {
+		Size int64 `json:"size"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || req.Size <= 0 || req.Size > backup.MaxArchiveSize {
+		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("size must be between 1 and %d bytes", backup.MaxArchiveSize))
+		return
+	}
+
 	uploadID, err := generateUploadID()
 	if err != nil {
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error generating upload ID: %v", err))
@@ -97,6 +152,17 @@ func InitChunkUpload(c *gin.Context) {
 	}
 	if err := os.MkdirAll(chunkDir, 0755); err != nil {
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating upload directory: %v", err))
+		return
+	}
+	metadata, err := json.Marshal(chunkUploadMetadata{Size: req.Size})
+	if err != nil {
+		cleanupChunkDir(chunkDir)
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error encoding upload metadata: %v", err))
+		return
+	}
+	if err := os.WriteFile(filepath.Join(chunkDir, uploadMetadataName), metadata, 0600); err != nil {
+		cleanupChunkDir(chunkDir)
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error writing upload metadata: %v", err))
 		return
 	}
 
@@ -139,24 +205,57 @@ func UploadChunk(c *gin.Context) {
 	}
 	defer file.Close()
 
+	chunkUploadMu.Lock()
+	defer chunkUploadMu.Unlock()
+	metadata, err := readChunkUploadMetadata(chunkDir)
+	if err != nil {
+		api.RespondError(c, http.StatusNotFound, "upload_id not found or expired")
+		return
+	}
+
 	chunkPath := filepath.Join(chunkDir, fmt.Sprintf("%d.part", chunkIndex))
-	out, err := os.Create(chunkPath)
+	tempChunk, err := os.CreateTemp(chunkDir, fmt.Sprintf(".%d-*.part", chunkIndex))
 	if err != nil {
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error saving chunk: %v", err))
 		return
 	}
+	tempChunkPath := tempChunk.Name()
+	defer os.Remove(tempChunkPath)
 
-	written, err := io.Copy(out, io.LimitReader(file, defaultChunkSize+1))
-	if closeErr := out.Close(); err == nil {
+	written, err := io.Copy(tempChunk, io.LimitReader(file, defaultChunkSize+1))
+	if closeErr := tempChunk.Close(); err == nil {
 		err = closeErr
 	}
 	if err != nil || written > defaultChunkSize {
-		os.Remove(chunkPath)
 		if err != nil {
 			api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error writing chunk: %v", err))
 		} else {
 			api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Chunk too large: %d bytes (max %d)", written, defaultChunkSize))
 		}
+		return
+	}
+	currentSize, err := chunkUploadSize(chunkDir)
+	if err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error checking uploaded chunks: %v", err))
+		return
+	}
+	oldSize := int64(0)
+	if info, err := os.Stat(chunkPath); err == nil {
+		oldSize = info.Size()
+	} else if !os.IsNotExist(err) {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error checking existing chunk: %v", err))
+		return
+	}
+	if currentSize-oldSize+written > metadata.Size {
+		api.RespondError(c, http.StatusBadRequest, "uploaded chunks exceed the declared backup size")
+		return
+	}
+	if err := os.Remove(chunkPath); err != nil && !os.IsNotExist(err) {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error replacing chunk: %v", err))
+		return
+	}
+	if err := os.Rename(tempChunkPath, chunkPath); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error publishing chunk: %v", err))
 		return
 	}
 
@@ -168,6 +267,18 @@ func UploadChunk(c *gin.Context) {
 
 // MergeChunkUpload 合并分块 → 校验 ZIP → 保存到 data/backup/ → 触发恢复。
 func MergeChunkUpload(c *gin.Context) {
+	restoreLock, err := backup.AcquireRestoreLock()
+	if err != nil {
+		api.RespondError(c, http.StatusConflict, err.Error())
+		return
+	}
+	keepRestoreLock := false
+	defer func() {
+		if !keepRestoreLock {
+			restoreLock.Release()
+		}
+	}()
+
 	var req struct {
 		UploadID string `json:"upload_id" binding:"required"`
 	}
@@ -183,6 +294,21 @@ func MergeChunkUpload(c *gin.Context) {
 	}
 	if info, err := os.Stat(chunkDir); err != nil || !info.IsDir() {
 		api.RespondError(c, http.StatusNotFound, "upload_id not found or expired")
+		return
+	}
+	chunkUploadMu.Lock()
+	defer chunkUploadMu.Unlock()
+	metadata, err := readChunkUploadMetadata(chunkDir)
+	if err != nil {
+		api.RespondError(c, http.StatusNotFound, "upload_id not found or expired")
+		return
+	}
+	if uploadedSize, err := chunkUploadSize(chunkDir); err != nil || uploadedSize != metadata.Size {
+		if err != nil {
+			api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error checking uploaded chunks: %v", err))
+		} else {
+			api.RespondError(c, http.StatusBadRequest, "uploaded chunk size does not match the declared backup size")
+		}
 		return
 	}
 
@@ -227,7 +353,7 @@ func MergeChunkUpload(c *gin.Context) {
 		return
 	}
 	defer archive.Close()
-	if err := backup.SaveUploadedBackup(archive, archiveName); err != nil {
+	if err := restoreLock.SaveUploadedBackup(archive, archiveName); err != nil {
 		cleanupChunkDir(chunkDir)
 		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Error preparing restore: %v", err))
 		return
@@ -241,9 +367,11 @@ func MergeChunkUpload(c *gin.Context) {
 		"path":    filepath.Join(".", "data", "backup.zip"),
 	})
 
+	keepRestoreLock = true
 	go func() {
 		log.Println("Backup uploaded (chunk), restarting service in 2 seconds to apply on startup...")
 		time.Sleep(2 * time.Second)
+		restoreLock.Release()
 		os.Exit(0)
 	}()
 }
@@ -287,18 +415,10 @@ func mergeChunks(chunkDir, destPath string) error {
 
 // validateBackupZip 校验 ZIP 结构完整性及 komari-backup-markup 标记文件。
 func validateBackupZip(zipPath string) error {
-	zr, err := zip.OpenReader(zipPath)
-	if err != nil {
-		return fmt.Errorf("not a valid zip file: %v", err)
+	if err := backup.ValidateArchive(zipPath); err != nil {
+		return fmt.Errorf("not a valid backup archive: %w", err)
 	}
-	defer zr.Close()
-
-	for _, f := range zr.File {
-		if f.Name == "komari-backup-markup" {
-			return nil
-		}
-	}
-	return fmt.Errorf("missing komari-backup-markup file")
+	return nil
 }
 
 // cleanupChunkDir 清理临时上传目录。

--- a/web/api/admin/chunk_upload.go
+++ b/web/api/admin/chunk_upload.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -321,15 +322,26 @@ func MergeChunkUpload(c *gin.Context) {
 	archiveName := fmt.Sprintf("backup-%s.zip", time.Now().UTC().Format("20060102-150405.000000"))
 
 	mergedPath := filepath.Join(chunkDir, "merged.zip")
-	if err := mergeChunks(chunkDir, mergedPath); err != nil {
+	if err := mergeChunks(c.Request.Context(), chunkDir, mergedPath); err != nil {
 		cleanupChunkDir(chunkDir)
+		if c.Request.Context().Err() != nil {
+			return
+		}
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error merging chunks: %v", err))
+		return
+	}
+	if c.Request.Context().Err() != nil {
+		cleanupChunkDir(chunkDir)
 		return
 	}
 
 	if err := validateBackupZip(mergedPath); err != nil {
 		cleanupChunkDir(chunkDir)
 		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Invalid backup: %v", err))
+		return
+	}
+	if c.Request.Context().Err() != nil {
+		cleanupChunkDir(chunkDir)
 		return
 	}
 
@@ -358,6 +370,13 @@ func MergeChunkUpload(c *gin.Context) {
 		api.RespondError(c, http.StatusBadRequest, fmt.Sprintf("Error preparing restore: %v", err))
 		return
 	}
+	if c.Request.Context().Err() != nil {
+		if err := os.Remove(filepath.Join(".", "data", "backup.zip")); err != nil && !os.IsNotExist(err) {
+			log.Printf("[chunk_upload] failed to discard cancelled restore: %v", err)
+		}
+		cleanupChunkDir(chunkDir)
+		return
+	}
 
 	cleanupChunkDir(chunkDir)
 
@@ -377,7 +396,7 @@ func MergeChunkUpload(c *gin.Context) {
 }
 
 // mergeChunks 按分块索引数值排序后顺序合并所有 .part 文件。
-func mergeChunks(chunkDir, destPath string) error {
+func mergeChunks(ctx context.Context, chunkDir, destPath string) error {
 	parts, err := filepath.Glob(filepath.Join(chunkDir, "*.part"))
 	if err != nil {
 		return err
@@ -400,6 +419,9 @@ func mergeChunks(chunkDir, destPath string) error {
 	defer out.Close()
 
 	for _, partPath := range parts {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		f, err := os.Open(partPath)
 		if err != nil {
 			return fmt.Errorf("error opening chunk %s: %v", filepath.Base(partPath), err)

--- a/web/api/admin/download.go
+++ b/web/api/admin/download.go
@@ -42,128 +42,20 @@ func copyFile(srcPath, destPath string) error {
 	return nil
 }
 
-// copyDataToTempExcludingDB 将 ./data 下除了 .db/.db-wal/.db-shm 之外的所有文件复制到临时目录
-func copyDataToTempExcludingDB(tempDir string) error {
-	dataRoot := "./data"
-
-	// 如果 data 目录不存在，视为无文件可复制
-	if stat, err := os.Stat(dataRoot); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("stat data dir: %v", err)
-	} else if !stat.IsDir() {
-		return fmt.Errorf("%s is not a directory", dataRoot)
-	}
-
-	return filepath.Walk(dataRoot, func(p string, info os.FileInfo, err error) error {
+// walkDirToZip 将 contentDir 的内容写入 zip writer。
+// 注意：contentDir 不应包含被 walk 的 zip 文件本身。
+func walkDirToZip(zipWriter *zip.Writer, contentDir string) error {
+	return filepath.Walk(contentDir, func(p string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-
-		rel, err := filepath.Rel(dataRoot, p)
+		rel, err := filepath.Rel(contentDir, p)
 		if err != nil {
 			return err
 		}
 		if rel == "." {
 			return nil
 		}
-
-		// 跳过数据库相关文件
-		name := info.Name()
-		if strings.HasSuffix(strings.ToLower(name), ".db") ||
-			strings.HasSuffix(strings.ToLower(name), ".db-wal") ||
-			strings.HasSuffix(strings.ToLower(name), ".db-shm") {
-			return nil
-		}
-
-		dst := filepath.Join(tempDir, rel)
-		if info.IsDir() {
-			return os.MkdirAll(dst, 0o755)
-		}
-		return copyFile(p, dst)
-	})
-}
-
-// backupSQLiteTo 使用 SQLite VACUUM INTO 将当前数据库一致性备份到指定路径
-func backupSQLiteTo(destDBPath string) error {
-	if err := os.MkdirAll(filepath.Dir(destDBPath), 0o755); err != nil {
-		return fmt.Errorf("failed to create parent directory for db: %v", err)
-	}
-
-	db := dbcore.GetDBInstance()
-	sqlDB, err := db.DB()
-	if err != nil {
-		return fmt.Errorf("failed to get underlying database connection: %v", err)
-	}
-
-	safePath := strings.ReplaceAll(destDBPath, "'", "''")
-	vacuumSQL := fmt.Sprintf("VACUUM INTO '%s'", safePath)
-	if _, err = sqlDB.Exec(vacuumSQL); err != nil {
-		return fmt.Errorf("sqlite VACUUM INTO failed: %v", err)
-	}
-	return nil
-}
-
-// DownloadBackup 用于打包 ./data 目录及数据库文件为 zip 并通过 HTTP 下载
-func DownloadBackup(c *gin.Context) {
-	// 1) 创建临时目录
-	tempDir, err := os.MkdirTemp("", "komari-backup-*")
-	if err != nil {
-		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating temporary directory: %v", err))
-		return
-	}
-	defer os.RemoveAll(tempDir)
-
-	// 2) 复制 ./data 下除 .db/.db-wal/.db-shm 外的所有文件到临时目录
-	if err := copyDataToTempExcludingDB(tempDir); err != nil {
-		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error copying data to temp: %v", err))
-		return
-	}
-
-	// 3) 处理数据库备份 -> 临时目录/komari.db
-	destDB := filepath.Join(tempDir, "komari.db")
-	dbFilePath := flags.DatabaseFile
-
-	if flags.IsSQLite() {
-		if err := backupSQLiteTo(destDB); err != nil {
-			api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error backing up sqlite database: %v", err))
-			return
-		}
-	} else if dbFilePath != "" {
-		// 非 sqlite 的情况：若配置了文件路径且存在，则直接复制（按用户需求仍然将名称固定为 komari.db）
-		if _, err := os.Stat(dbFilePath); err == nil {
-			if err := copyFile(dbFilePath, destDB); err != nil {
-				api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error copying database file: %v", err))
-				return
-			}
-		} else if !os.IsNotExist(err) {
-			api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error stating database file: %v", err))
-			return
-		}
-	}
-
-	// 4) 开始写出 ZIP（以临时目录为根）
-	backupFileName := fmt.Sprintf("backup-%d.zip", time.Now().UnixMicro())
-	c.Writer.Header().Set("Content-Type", "application/zip")
-	c.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", backupFileName))
-
-	zipWriter := zip.NewWriter(c.Writer)
-	defer zipWriter.Close()
-
-	// 写入临时目录里的内容
-	err = filepath.Walk(tempDir, func(p string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(tempDir, p)
-		if err != nil {
-			return err
-		}
-		if rel == "." {
-			return nil
-		}
-		// zip 内路径统一正斜杠
 		zipPath := filepath.ToSlash(rel)
 		if info.IsDir() {
 			_, err := zipWriter.CreateHeader(&zip.FileHeader{
@@ -189,12 +81,10 @@ func DownloadBackup(c *gin.Context) {
 		_, err = io.Copy(w, f)
 		return err
 	})
-	if err != nil {
-		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error archiving temp folder: %v", err))
-		return
-	}
+}
 
-	// 5) 追加备份标记文件（放在 zip 根目录）
+// writeBackupMarkup 追加备份标记文件到 zip。
+func writeBackupMarkup(zipWriter *zip.Writer) error {
 	now := time.Now().UTC()
 	markupContent := "此文件为 Komari 备份标记文件，请勿删除。\nThis is a Komari backup markup file, please do not delete.\n\n备份时间 / Backup Time: " + now.Format(time.RFC3339Nano)
 	markupWriter, err := zipWriter.CreateHeader(&zip.FileHeader{
@@ -203,17 +93,181 @@ func DownloadBackup(c *gin.Context) {
 		Modified: now,
 	})
 	if err != nil {
-		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating backup markup file: %v", err))
-		return
+		return err
 	}
-	if _, err = markupWriter.Write([]byte(markupContent)); err != nil {
-		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error writing backup markup file: %v", err))
-		return
-	}
+	_, err = markupWriter.Write([]byte(markupContent))
+	return err
 }
 
-// pruneOldZipByPrefix 裁剪旧备份文件，仅保留最近 keep 份。
-// 文件名格式 {prefix}YYYYMMDD-HHmmSS.zip，按名称字典序即时间序。
+// backupSQLiteTo 使用 SQLite VACUUM INTO 将当前数据库一致性备份到指定路径。
+// destDBPath 会先删除以防 SQLite 报 "output file already exists"。
+func backupSQLiteTo(destDBPath string) error {
+	if err := os.MkdirAll(filepath.Dir(destDBPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create parent directory for db: %v", err)
+	}
+
+	// 确保目标文件不存在（VACUUM INTO 要求目标文件不存在）
+	_ = os.Remove(destDBPath)
+
+	db := dbcore.GetDBInstance()
+	sqlDB, err := db.DB()
+	if err != nil {
+		return fmt.Errorf("failed to get underlying database connection: %v", err)
+	}
+
+	// Windows 下 VACUUM INTO 传绝对路径时，统一使用正斜杠避免路径解析歧义
+	safePath := filepath.ToSlash(destDBPath)
+	safePath = strings.ReplaceAll(safePath, "'", "''")
+	vacuumSQL := fmt.Sprintf("VACUUM INTO '%s'", safePath)
+	if _, err = sqlDB.Exec(vacuumSQL); err != nil {
+		return fmt.Errorf("sqlite VACUUM INTO failed: %v", err)
+	}
+	return nil
+}
+
+// DownloadBackup 使用白名单打包 ./data 及数据库文件为 zip 并下载，
+// 同时归档到 ./data/backup/ 确保 Docker 挂载后备份文件可持久化。
+//
+// 短时去重：一分钟内重复请求直接返回最近备份，避免网络不佳或下载管理器重复调用
+// TODO: 后续需前端配合改为自动获取备份列表并展示的方式 弃用旧版本函数
+func DownloadBackup(c *gin.Context) {
+	backupDir := filepath.Join(".", "data", "backup")
+
+	// 0) 短时去重：检查最近一分钟 backup-*.zip 是否在窗口内
+	const dedupWindow = 60 * time.Second
+	if entries, readErr := os.ReadDir(backupDir); readErr == nil {
+		var latest os.DirEntry
+		var latestTime time.Time
+		for _, e := range entries {
+			name := strings.ToLower(e.Name())
+			if e.IsDir() || !strings.HasPrefix(name, "backup-") || !strings.HasSuffix(name, ".zip") {
+				continue
+			}
+			info, _ := e.Info()
+			if info != nil && info.ModTime().After(latestTime) {
+				latestTime = info.ModTime()
+				latest = e
+			}
+		}
+		if latest != nil && time.Since(latestTime) < dedupWindow {
+			cachedPath := filepath.Join(backupDir, latest.Name())
+			f, err := os.Open(cachedPath)
+			if err == nil {
+				defer f.Close()
+				c.Writer.Header().Set("Content-Type", "application/zip")
+				c.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", latest.Name()))
+				http.ServeContent(c.Writer, c.Request, latest.Name(), latestTime, f)
+				return
+			}
+		}
+	}
+
+	// 1) 创建临时目录，内容隔离到 content/ 子目录
+	tempDir, err := os.MkdirTemp("", "komari-backup-*")
+	if err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating temporary directory: %v", err))
+		return
+	}
+	defer os.RemoveAll(tempDir)
+
+	contentDir := filepath.Join(tempDir, "content")
+	if err := os.MkdirAll(contentDir, 0o755); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating content directory: %v", err))
+		return
+	}
+
+	// 2) 复制白名单文件到 content 目录
+	if err := copyWhitelistedFiles(contentDir); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error copying data to temp: %v", err))
+		return
+	}
+
+	// 3) 处理数据库备份 -> content/komari.db
+	destDB := filepath.Join(contentDir, "komari.db")
+	dbFilePath := flags.DatabaseFile
+
+	if flags.IsSQLite() {
+		if err := backupSQLiteTo(destDB); err != nil {
+			api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error backing up sqlite database: %v", err))
+			return
+		}
+	} else if dbFilePath != "" {
+		if _, err := os.Stat(dbFilePath); err == nil {
+			if err := copyFile(dbFilePath, destDB); err != nil {
+				api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error copying database file: %v", err))
+				return
+			}
+		} else if !os.IsNotExist(err) {
+			api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error stating database file: %v", err))
+			return
+		}
+	}
+
+	// 4) 打包到临时 ZIP（放在 tempDir 下，与 content 平级）
+	tempZipPath := filepath.Join(tempDir, "output.zip")
+	tempZip, err := os.Create(tempZipPath)
+	if err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating temp zip: %v", err))
+		return
+	}
+	zipWriter := zip.NewWriter(tempZip)
+
+	// 只 walk content 目录，避免 output.zip 被打包进去
+	if err := walkDirToZip(zipWriter, contentDir); err != nil {
+		zipWriter.Close()
+		tempZip.Close()
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error archiving temp folder: %v", err))
+		return
+	}
+
+	if err := writeBackupMarkup(zipWriter); err != nil {
+		zipWriter.Close()
+		tempZip.Close()
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error writing backup markup: %v", err))
+		return
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		tempZip.Close()
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error finalizing zip: %v", err))
+		return
+	}
+	tempZip.Close()
+
+	// 5) 归档到 data/backup/backup-YYYYMMDD-HHmmSS.zip
+	ts := time.Now().UTC().Format("20060102-150405")
+	archiveName := fmt.Sprintf("backup-%s.zip", ts)
+
+	archivePath := filepath.Join(backupDir, archiveName)
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating backup directory: %v", err))
+		return
+	}
+
+	if err := copyFile(tempZipPath, archivePath); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error archiving backup: %v", err))
+		return
+	}
+
+	// 裁剪旧备份：仅保留最近 3 份 backup-* 类型
+	pruneOldZipByPrefix(backupDir, "backup-", 3)
+
+	// 6) 发送给客户端
+	c.Writer.Header().Set("Content-Type", "application/zip")
+	c.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", archiveName))
+
+	zipReader, err := os.Open(tempZipPath)
+	if err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error reading temp zip: %v", err))
+		return
+	}
+	defer zipReader.Close()
+
+	http.ServeContent(c.Writer, c.Request, archiveName, time.Now(), zipReader)
+}
+
+// pruneOldZipByPrefix 裁剪指定前缀的 .zip 文件，仅保留最近 keep 份。
+// 文件名格式 {prefix}YYYYMMDD-HHmmSS.zip，按名称字典序即为时间序。
 func pruneOldZipByPrefix(backupDir, prefix string, keep int) {
 	entries, err := os.ReadDir(backupDir)
 	if err != nil {

--- a/web/api/admin/download.go
+++ b/web/api/admin/download.go
@@ -4,9 +4,11 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -207,5 +209,39 @@ func DownloadBackup(c *gin.Context) {
 	if _, err = markupWriter.Write([]byte(markupContent)); err != nil {
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error writing backup markup file: %v", err))
 		return
+	}
+}
+
+// pruneOldZipByPrefix 裁剪旧备份文件，仅保留最近 keep 份。
+// 文件名格式 {prefix}YYYYMMDD-HHmmSS.zip，按名称字典序即时间序。
+func pruneOldZipByPrefix(backupDir, prefix string, keep int) {
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		return
+	}
+
+	lowerPrefix := strings.ToLower(prefix)
+	var files []os.DirEntry
+	for _, e := range entries {
+		name := strings.ToLower(e.Name())
+		if e.IsDir() || !strings.HasPrefix(name, lowerPrefix) || !strings.HasSuffix(name, ".zip") {
+			continue
+		}
+		files = append(files, e)
+	}
+
+	if len(files) <= keep {
+		return
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Name() < files[j].Name()
+	})
+
+	for i := 0; i < len(files)-keep; i++ {
+		path := filepath.Join(backupDir, files[i].Name())
+		if err := os.Remove(path); err != nil {
+			log.Printf("[prune] failed to remove old %s %s: %v", prefix, path, err)
+		}
 	}
 }

--- a/web/api/admin/download.go
+++ b/web/api/admin/download.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -17,6 +18,8 @@ import (
 	"github.com/komari-monitor/komari/database/dbcore"
 	"github.com/komari-monitor/komari/web/api"
 )
+
+var backupArchiveMu sync.Mutex
 
 // copyFile 复制单个文件到目标路径（会确保父目录存在）
 func copyFile(srcPath, destPath string) error {
@@ -132,6 +135,8 @@ func backupSQLiteTo(destDBPath string) error {
 // TODO: 后续需前端配合改为自动获取备份列表并展示的方式 弃用旧版本函数
 func DownloadBackup(c *gin.Context) {
 	backupDir := filepath.Join(".", "data", "backup")
+	backupArchiveMu.Lock()
+	defer backupArchiveMu.Unlock()
 
 	// 0) 短时去重：检查最近一分钟 backup-*.zip 是否在窗口内
 	const dedupWindow = 60 * time.Second
@@ -234,8 +239,8 @@ func DownloadBackup(c *gin.Context) {
 	}
 	tempZip.Close()
 
-	// 5) 归档到 data/backup/backup-YYYYMMDD-HHmmSS.zip
-	ts := time.Now().UTC().Format("20060102-150405")
+	// 5) 归档到 data/backup/。先写临时文件再原子发布，去重请求不会读到半写入文件。
+	ts := time.Now().UTC().Format("20060102-150405.000000")
 	archiveName := fmt.Sprintf("backup-%s.zip", ts)
 
 	archivePath := filepath.Join(backupDir, archiveName)
@@ -244,8 +249,24 @@ func DownloadBackup(c *gin.Context) {
 		return
 	}
 
-	if err := copyFile(tempZipPath, archivePath); err != nil {
+	archiveTemp, err := os.CreateTemp(backupDir, ".backup-*.tmp")
+	if err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error creating archive temp file: %v", err))
+		return
+	}
+	archiveTempPath := archiveTemp.Name()
+	if err := archiveTemp.Close(); err != nil {
+		os.Remove(archiveTempPath)
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error closing archive temp file: %v", err))
+		return
+	}
+	defer os.Remove(archiveTempPath)
+	if err := copyFile(tempZipPath, archiveTempPath); err != nil {
 		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error archiving backup: %v", err))
+		return
+	}
+	if err := os.Rename(archiveTempPath, archivePath); err != nil {
+		api.RespondError(c, http.StatusInternalServerError, fmt.Sprintf("Error publishing backup archive: %v", err))
 		return
 	}
 

--- a/web/api/admin/download.go
+++ b/web/api/admin/download.go
@@ -4,13 +4,10 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -18,8 +15,6 @@ import (
 	"github.com/komari-monitor/komari/database/dbcore"
 	"github.com/komari-monitor/komari/web/api"
 )
-
-var backupArchiveMu sync.Mutex
 
 // copyFile 复制单个文件到目标路径（会确保父目录存在）
 func copyFile(srcPath, destPath string) error {
@@ -131,41 +126,9 @@ func backupSQLiteTo(destDBPath string) error {
 // DownloadBackup 使用白名单打包 ./data 及数据库文件为 zip 并下载，
 // 同时归档到 ./data/backup/ 确保 Docker 挂载后备份文件可持久化。
 //
-// 短时去重：一分钟内重复请求直接返回最近备份，避免网络不佳或下载管理器重复调用
-// TODO: 后续需前端配合改为自动获取备份列表并展示的方式 弃用旧版本函数
+// 归档文件由前端后续统一管理，服务端只负责生成并保存。
 func DownloadBackup(c *gin.Context) {
 	backupDir := filepath.Join(".", "data", "backup")
-	backupArchiveMu.Lock()
-	defer backupArchiveMu.Unlock()
-
-	// 0) 短时去重：检查最近一分钟 backup-*.zip 是否在窗口内
-	const dedupWindow = 60 * time.Second
-	if entries, readErr := os.ReadDir(backupDir); readErr == nil {
-		var latest os.DirEntry
-		var latestTime time.Time
-		for _, e := range entries {
-			name := strings.ToLower(e.Name())
-			if e.IsDir() || !strings.HasPrefix(name, "backup-") || !strings.HasSuffix(name, ".zip") {
-				continue
-			}
-			info, _ := e.Info()
-			if info != nil && info.ModTime().After(latestTime) {
-				latestTime = info.ModTime()
-				latest = e
-			}
-		}
-		if latest != nil && time.Since(latestTime) < dedupWindow {
-			cachedPath := filepath.Join(backupDir, latest.Name())
-			f, err := os.Open(cachedPath)
-			if err == nil {
-				defer f.Close()
-				c.Writer.Header().Set("Content-Type", "application/zip")
-				c.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", latest.Name()))
-				http.ServeContent(c.Writer, c.Request, latest.Name(), latestTime, f)
-				return
-			}
-		}
-	}
 
 	// 1) 创建临时目录，内容隔离到 content/ 子目录
 	tempDir, err := os.MkdirTemp("", "komari-backup-*")
@@ -239,7 +202,7 @@ func DownloadBackup(c *gin.Context) {
 	}
 	tempZip.Close()
 
-	// 5) 归档到 data/backup/。先写临时文件再原子发布，去重请求不会读到半写入文件。
+	// 5) 归档到 data/backup/。先写临时文件再原子发布。
 	ts := time.Now().UTC().Format("20060102-150405.000000")
 	archiveName := fmt.Sprintf("backup-%s.zip", ts)
 
@@ -270,9 +233,6 @@ func DownloadBackup(c *gin.Context) {
 		return
 	}
 
-	// 裁剪旧备份：仅保留最近 3 份 backup-* 类型
-	pruneOldZipByPrefix(backupDir, "backup-", 3)
-
 	// 6) 发送给客户端
 	c.Writer.Header().Set("Content-Type", "application/zip")
 	c.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", archiveName))
@@ -285,38 +245,4 @@ func DownloadBackup(c *gin.Context) {
 	defer zipReader.Close()
 
 	http.ServeContent(c.Writer, c.Request, archiveName, time.Now(), zipReader)
-}
-
-// pruneOldZipByPrefix 裁剪指定前缀的 .zip 文件，仅保留最近 keep 份。
-// 文件名格式 {prefix}YYYYMMDD-HHmmSS.zip，按名称字典序即为时间序。
-func pruneOldZipByPrefix(backupDir, prefix string, keep int) {
-	entries, err := os.ReadDir(backupDir)
-	if err != nil {
-		return
-	}
-
-	lowerPrefix := strings.ToLower(prefix)
-	var files []os.DirEntry
-	for _, e := range entries {
-		name := strings.ToLower(e.Name())
-		if e.IsDir() || !strings.HasPrefix(name, lowerPrefix) || !strings.HasSuffix(name, ".zip") {
-			continue
-		}
-		files = append(files, e)
-	}
-
-	if len(files) <= keep {
-		return
-	}
-
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].Name() < files[j].Name()
-	})
-
-	for i := 0; i < len(files)-keep; i++ {
-		path := filepath.Join(backupDir, files[i].Name())
-		if err := os.Remove(path); err != nil {
-			log.Printf("[prune] failed to remove old %s %s: %v", prefix, path, err)
-		}
-	}
 }

--- a/web/api/admin/upload.go
+++ b/web/api/admin/upload.go
@@ -20,7 +20,13 @@ func UploadBackup(c *gin.Context) {
 		return
 	}
 	defer file.Close()
-	if err := backup.SaveUploadedBackup(file, header.Filename); err != nil {
+	restoreLock, err := backup.AcquireRestoreLock()
+	if err != nil {
+		api.RespondError(c, http.StatusConflict, err.Error())
+		return
+	}
+	if err := restoreLock.SaveUploadedBackup(file, header.Filename); err != nil {
+		restoreLock.Release()
 		api.RespondError(c, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -33,6 +39,7 @@ func UploadBackup(c *gin.Context) {
 	go func() {
 		logger.InfoArgs("admin-api", "Backup uploaded, restarting service in 2 seconds to apply on startup...")
 		time.Sleep(2 * time.Second)
+		restoreLock.Release()
 		os.Exit(0)
 	}()
 }

--- a/web/backup/restore.go
+++ b/web/backup/restore.go
@@ -13,14 +13,42 @@ import (
 
 var restoreMutex sync.Mutex
 
+const (
+	MaxArchiveSize    int64 = 4 << 30 // 4 GiB
+	maxArchiveEntries       = 100_000
+)
+
+// RestoreLock serializes staging a backup until the caller releases it.
+// A successful restore must hold this lock until the process restarts so a
+// second request cannot replace backup.zip in the meantime.
+type RestoreLock struct {
+	once sync.Once
+}
+
+func AcquireRestoreLock() (*RestoreLock, error) {
+	if !restoreMutex.TryLock() {
+		return nil, fmt.Errorf("another restore operation is already in progress")
+	}
+	return &RestoreLock{}, nil
+}
+
+func (l *RestoreLock) Release() {
+	l.once.Do(restoreMutex.Unlock)
+}
+
 // SaveUploadedBackup validates a Komari backup and stages it for restoration
 // during the next process startup.
 func SaveUploadedBackup(file io.Reader, filename string) error {
-	if !restoreMutex.TryLock() {
-		return fmt.Errorf("another restore operation is already in progress")
+	lock, err := AcquireRestoreLock()
+	if err != nil {
+		return err
 	}
-	defer restoreMutex.Unlock()
+	defer lock.Release()
+	return lock.SaveUploadedBackup(file, filename)
+}
 
+// SaveUploadedBackup stages a backup while the caller holds the restore lock.
+func (l *RestoreLock) SaveUploadedBackup(file io.Reader, filename string) error {
 	if !strings.HasSuffix(strings.ToLower(filename), ".zip") {
 		return fmt.Errorf("uploaded file must be a ZIP archive")
 	}
@@ -28,34 +56,29 @@ func SaveUploadedBackup(file io.Reader, filename string) error {
 		return fmt.Errorf("create data directory: %w", err)
 	}
 
-	tempFile, err := os.CreateTemp("", "backup-upload-*.zip")
+	// Stage alongside backup.zip so the final rename is atomic on every
+	// supported platform and never crosses filesystem boundaries.
+	tempFile, err := os.CreateTemp("./data", ".backup-upload-*.zip")
 	if err != nil {
 		return fmt.Errorf("create temporary backup: %w", err)
 	}
 	tempPath := tempFile.Name()
 	defer os.Remove(tempPath)
-	if _, err := io.Copy(tempFile, file); err != nil {
+	written, err := io.Copy(tempFile, io.LimitReader(file, MaxArchiveSize+1))
+	if err != nil {
 		tempFile.Close()
 		return fmt.Errorf("save uploaded backup: %w", err)
+	}
+	if written > MaxArchiveSize {
+		tempFile.Close()
+		return fmt.Errorf("backup archive exceeds the %d byte limit", MaxArchiveSize)
 	}
 	if err := tempFile.Close(); err != nil {
 		return fmt.Errorf("close uploaded backup: %w", err)
 	}
 
-	reader, err := zip.OpenReader(tempPath)
-	if err != nil {
-		return fmt.Errorf("open backup archive: %w", err)
-	}
-	hasMarkup := false
-	for _, entry := range reader.File {
-		if entry.Name == "komari-backup-markup" {
-			hasMarkup = true
-			break
-		}
-	}
-	reader.Close()
-	if !hasMarkup {
-		return fmt.Errorf("invalid backup file: missing komari-backup-markup file")
+	if err := ValidateArchive(tempPath); err != nil {
+		return err
 	}
 
 	finalPath := filepath.Join(".", "data", "backup.zip")
@@ -80,6 +103,36 @@ func SaveUploadedBackup(file io.Reader, filename string) error {
 	}
 	if err := out.Close(); err != nil {
 		return fmt.Errorf("close backup file: %w", err)
+	}
+	return nil
+}
+
+// ValidateArchive checks the backup marker and bounds archive expansion before
+// the startup restore path extracts it into data/.
+func ValidateArchive(path string) error {
+	reader, err := zip.OpenReader(path)
+	if err != nil {
+		return fmt.Errorf("open backup archive: %w", err)
+	}
+	defer reader.Close()
+
+	if len(reader.File) > maxArchiveEntries {
+		return fmt.Errorf("backup archive has too many files: %d", len(reader.File))
+	}
+
+	var expandedSize uint64
+	hasMarkup := false
+	for _, entry := range reader.File {
+		if entry.Name == "komari-backup-markup" {
+			hasMarkup = true
+		}
+		if entry.UncompressedSize64 > uint64(MaxArchiveSize) || expandedSize > uint64(MaxArchiveSize)-entry.UncompressedSize64 {
+			return fmt.Errorf("backup archive expands beyond the %d byte limit", MaxArchiveSize)
+		}
+		expandedSize += entry.UncompressedSize64
+	}
+	if !hasMarkup {
+		return fmt.Errorf("invalid backup file: missing komari-backup-markup file")
 	}
 	return nil
 }

--- a/web/backup/restore_test.go
+++ b/web/backup/restore_test.go
@@ -1,0 +1,52 @@
+package backup
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestArchive(t *testing.T, entries map[string]string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "backup.zip")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	writer := zip.NewWriter(file)
+	for name, content := range entries {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+		if _, err := entry.Write([]byte(content)); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close archive writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close archive file: %v", err)
+	}
+	return path
+}
+
+func TestValidateArchiveAcceptsLegacyRootLayout(t *testing.T) {
+	archive := writeTestArchive(t, map[string]string{
+		"komari.db":            "database",
+		"theme/config.json":    "{}",
+		"komari-backup-markup": "backup marker",
+	})
+	if err := ValidateArchive(archive); err != nil {
+		t.Fatalf("ValidateArchive rejected legacy root layout: %v", err)
+	}
+}
+
+func TestValidateArchiveRequiresMarkup(t *testing.T) {
+	archive := writeTestArchive(t, map[string]string{"komari.db": "database"})
+	if err := ValidateArchive(archive); err == nil {
+		t.Fatal("ValidateArchive accepted archive without markup")
+	}
+}

--- a/web/router/router.go
+++ b/web/router/router.go
@@ -86,6 +86,10 @@ func registerAdminRoutes(r *gin.Engine) {
 	// --- 二进制/流/重定向类，保留 REST handler ---
 	g.GET("/download/backup", admin.DownloadBackup)
 	g.POST("/upload/backup", admin.UploadBackup)
+	// chunk upload 用于大备份文件分块上传，提高稳定性
+	g.POST("/upload/backup/init", admin.InitChunkUpload)
+	g.POST("/upload/backup/chunk", admin.UploadChunk)
+	g.POST("/upload/backup/merge", admin.MergeChunkUpload)
 	g.GET("/test/geoip", jsonRpc.Bind("admin:testGeoip", jsonRpc.WithQuery("ip")))
 	g.POST("/test/sendMessage", jsonRpc.Bind("admin:testSendMessage"))
 	g.POST("/update/mmdb", admin.UpdateMmdbGeoIP)


### PR DESCRIPTION
备份恢复改为分块上传
下载先打包再下载 短时间直接返回文件避免下载器接管时再次触发打包 最多保存三份
目前方案为兼容方案 后续将改为显示备份文件列表管理