### PR TITLE
perf(metric): refresh planner statistics for the rollup read path

### DIFF
--- a/internal/metricstore/maintenance.go
+++ b/internal/metricstore/maintenance.go
@@ -58,6 +58,29 @@ func InspectStorage(ctx context.Context) (StorageInfo, error) {
 	return info, err
 }
 
+// UpdateStatistics refreshes query planner statistics for the active store.
+// It takes the shared lock because refreshing statistics only samples existing
+// rows and is safe to run alongside report writes and compaction; it must still
+// keep a store reload from closing the connection underneath it.
+//
+// UpdateStatistics 刷新当前 store 的查询计划统计信息。它只对已有数据采样,
+// 可与上报写入和压缩并发执行,因此取共享锁;但仍需防止 store 重载在执行过程中
+// 关闭底层连接。
+func UpdateStatistics(ctx context.Context) error {
+	if err := storeOperations.AcquireShared(ctx); err != nil {
+		return fmt.Errorf("wait for metric store operation before updating statistics: %w", err)
+	}
+	defer storeOperations.ReleaseShared()
+
+	storeMu.RLock()
+	activeStore := store
+	storeMu.RUnlock()
+	if activeStore == nil {
+		return ErrStoreNotInitialized
+	}
+	return activeStore.UpdateStatistics(ctx)
+}
+
 // ReclaimSpace performs the driver-specific physical maintenance operation.
 // It takes the exclusive operation lock, so a table/file rewrite cannot run
 // concurrently with report writes or compaction.

--- a/internal/server/runtime.go
+++ b/internal/server/runtime.go
@@ -218,4 +218,9 @@ func compactMetricStore(ctx context.Context) {
 	if written > 0 {
 		logger.Infof("server", "Metric store compacted %d rollup buckets", written)
 	}
+	// Compaction is the point where row counts shift the most, so it is also
+	// where refreshed planner statistics are worth the (bounded) cost.
+	if err := metricstore.UpdateStatistics(compactCtx); err != nil {
+		logger.Errorf("server", "Failed to update metric store statistics: %v", err)
+	}
 }

--- a/pkg/metric/maintenance.go
+++ b/pkg/metric/maintenance.go
@@ -27,6 +27,11 @@ const (
 const (
 	sqliteCheckpointSQL = "PRAGMA wal_checkpoint(TRUNCATE)"
 	sqliteVacuumSQL     = "VACUUM"
+	// sqliteAnalysisLimitSQL bounds the rows sampled per index so that refreshing
+	// statistics stays cheap regardless of how large the metric database grows.
+	// 400 is the value SQLite's own documentation recommends for this pattern.
+	sqliteAnalysisLimitSQL = "PRAGMA analysis_limit=400"
+	sqliteOptimizeSQL      = "PRAGMA optimize"
 )
 
 // Driver returns the Store's configured database backend.
@@ -89,6 +94,31 @@ func (s *Store) CheckpointWAL(ctx context.Context) error {
 		return nil
 	}
 	return sqliteCheckpoint(ctx, s.db)
+}
+
+// UpdateStatistics refreshes the query planner statistics behind the
+// normalized rollup schema. Reads reach a rollup row through two dictionary
+// joins, so choosing the series-first plan depends on the planner knowing that
+// metric_series is tiny while metric_rollups is not. Without sqlite_stat1 the
+// planner falls back to the resolution index and scans a whole tier per query.
+// Other backends maintain their own statistics automatically.
+//
+// UpdateStatistics 刷新规范化 rollup 表的查询计划统计信息。读取一行 rollup 需要
+// 经过两次字典表 JOIN,优化器只有知道 metric_series 很小、metric_rollups 很大,
+// 才会选择先定位 series 的执行计划;缺少 sqlite_stat1 时它会退化为走分辨率索引,
+// 每次查询扫描整个分辨率层。其他后端自行维护统计信息。
+func (s *Store) UpdateStatistics(ctx context.Context) error {
+	s.maintenanceMu.Lock()
+	defer s.maintenanceMu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed || s.db == nil {
+		return ErrClosed
+	}
+	if s.cfg.Driver != DriverSQLite {
+		return nil
+	}
+	return sqliteUpdateStatistics(ctx, s.db)
 }
 
 // ReclaimSpace performs the backend-specific blocking operation that returns
@@ -227,6 +257,22 @@ func sqliteCheckpoint(ctx context.Context, db *sql.DB) error {
 	}
 	if busy != 0 {
 		return fmt.Errorf("metric: checkpoint sqlite WAL: database is busy (%d log frames, %d checkpointed)", logFrames, checkpointedFrames)
+	}
+	return nil
+}
+
+func sqliteUpdateStatistics(ctx context.Context, db *sql.DB) error {
+	// analysis_limit caps how many index rows each ANALYZE samples, which keeps
+	// the cost bounded on large metric databases. PRAGMA optimize then only
+	// re-analyzes the tables whose content changed enough to matter.
+	//
+	// analysis_limit 限制每个索引的采样行数,使大型监控库上的开销保持恒定;
+	// PRAGMA optimize 随后只会重新分析内容变化足够大的表。
+	if _, err := db.ExecContext(ctx, sqliteAnalysisLimitSQL); err != nil {
+		return fmt.Errorf("metric: set sqlite analysis limit: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, sqliteOptimizeSQL); err != nil {
+		return fmt.Errorf("metric: optimize sqlite statistics: %w", err)
 	}
 	return nil
 }

--- a/pkg/metric/statistics_test.go
+++ b/pkg/metric/statistics_test.go
@@ -1,0 +1,235 @@
+package metric
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	plannerSeedEntities = 24
+	plannerSeedMinutes  = 240
+)
+
+// seedRollupsForPlanner writes enough series and buckets that the planner has a
+// real choice between the resolution index and the series-first plan. It
+// returns the bucket window covering the seeded data.
+func seedRollupsForPlanner(ctx context.Context, t *testing.T, store *Store) (time.Time, time.Time) {
+	t.Helper()
+	base := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	if err := store.CreateMetric(ctx, Definition{
+		Name:          "cpu.usage",
+		Type:          TypeGauge,
+		Unit:          "%",
+		RetentionDays: 30,
+	}); err != nil {
+		t.Fatalf("create metric: %v", err)
+	}
+
+	points := make([]Point, 0, plannerSeedEntities*plannerSeedMinutes)
+	for entity := 0; entity < plannerSeedEntities; entity++ {
+		entityID := fmt.Sprintf("host-%02d", entity)
+		for minute := 0; minute < plannerSeedMinutes; minute++ {
+			points = append(points, Point{
+				MetricName: "cpu.usage",
+				EntityID:   entityID,
+				Timestamp:  base.Add(time.Duration(minute) * time.Minute),
+				Value:      float64(minute % 97),
+			})
+		}
+	}
+	if err := store.WriteBatch(ctx, points); err != nil {
+		t.Fatalf("write batch: %v", err)
+	}
+	end := base.Add(time.Duration(plannerSeedMinutes) * time.Minute)
+	if _, err := store.Compact(ctx, end.Add(2*time.Hour)); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	return base, end
+}
+
+// capturingQuerier records the statement a Store method actually issues, so the
+// planner assertion below runs against the live query text instead of a copy
+// that silently rots when the query is rewritten.
+type capturingQuerier struct {
+	inner querier
+	sql   string
+	args  []any
+}
+
+func (c *capturingQuerier) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	c.sql = query
+	c.args = args
+	return c.inner.QueryContext(ctx, query, args...)
+}
+
+// captureRollupScan returns the statement scanRollupRowsBetween issues for a
+// single-entity read, which is the query AggregateRollup runs on every
+// dashboard refresh.
+func captureRollupScan(ctx context.Context, t *testing.T, store *Store, start, end time.Time) (string, []any) {
+	t.Helper()
+	capture := &capturingQuerier{inner: store.reader()}
+	if _, err := store.scanRollupRowsBetweenWith(ctx, capture, "cpu.usage", "host-01", nil,
+		time.Minute, start.UnixMilli(), end.UnixMilli(), false); err != nil {
+		t.Fatalf("scan rollup rows: %v", err)
+	}
+	if capture.sql == "" {
+		t.Fatal("rollup scan issued no statement")
+	}
+	return capture.sql, capture.args
+}
+
+func explainPlan(ctx context.Context, t *testing.T, store *Store, query string, args ...any) []string {
+	t.Helper()
+	rows, err := store.db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatalf("explain query plan: %v", err)
+	}
+	defer rows.Close()
+	var plan []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			t.Fatalf("scan plan row: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate plan rows: %v", err)
+	}
+	return plan
+}
+
+func rollupStatCount(ctx context.Context, t *testing.T, store *Store) int {
+	t.Helper()
+	var present int
+	if err := store.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='sqlite_stat1'`).Scan(&present); err != nil {
+		t.Fatalf("probe sqlite_stat1: %v", err)
+	}
+	if present == 0 {
+		return 0
+	}
+	var rows int
+	if err := store.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_stat1 WHERE tbl = ?`, store.tables.rollups).Scan(&rows); err != nil {
+		t.Fatalf("count rollup statistics: %v", err)
+	}
+	return rows
+}
+
+// TestUpdateStatisticsRecordsRollupPlan is the regression guard for the read
+// path behind komari-monitor/komari#626. Reaching a rollup row costs two
+// dictionary joins, so the planner only picks the series-first plan when it
+// knows metric_series is tiny while metric_rollups is not. Without sqlite_stat1
+// it falls back to the resolution index and scans a whole tier per call, which
+// AggregateRollup multiplies by entity count times metric count on every
+// dashboard refresh.
+//
+// The plan is asserted against the statement scanRollupRowsBetween actually
+// issues, so rewriting that query cannot leave the guard passing against a
+// shape the store no longer runs.
+func TestUpdateStatisticsRecordsRollupPlan(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, SQLiteInDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	start, end := seedRollupsForPlanner(ctx, t, store)
+	query, args := captureRollupScan(ctx, t, store, start, end)
+
+	if got := rollupStatCount(ctx, t, store); got != 0 {
+		t.Fatalf("rollup statistics before update = %d, want 0", got)
+	}
+
+	// Establish that the unanalyzed database really does reach the rollup table
+	// through the resolution index; otherwise the assertion after the refresh
+	// would pass without proving anything.
+	before := strings.Join(explainPlan(ctx, t, store, query, args...), "\n")
+	if !strings.Contains(before, "resolution_bucket_idx") {
+		t.Fatalf("unanalyzed plan does not scan the resolution tier, seed no longer reproduces the regression:\n%s", before)
+	}
+
+	if err := store.UpdateStatistics(ctx); err != nil {
+		t.Fatalf("update statistics: %v", err)
+	}
+
+	if got := rollupStatCount(ctx, t, store); got == 0 {
+		t.Fatal("update statistics recorded no sqlite_stat1 rows for the rollup table")
+	}
+
+	// The planner must now resolve the series before touching the rollup table.
+	plan := explainPlan(ctx, t, store, query, args...)
+	joined := strings.Join(plan, "\n")
+	for _, step := range plan {
+		if strings.Contains(step, store.tables.rollups) && strings.Contains(step, "resolution_bucket_idx") {
+			t.Fatalf("planner still scans the rollup tier through the resolution index:\n%s", joined)
+		}
+	}
+	if !strings.Contains(joined, "series_id=?") {
+		t.Fatalf("planner does not seek the rollup table by series:\n%s", joined)
+	}
+}
+
+// TestUpdateStatisticsIsBoundedAndRepeatable keeps the maintenance hook safe to
+// call from the five-minute compaction schedule.
+func TestUpdateStatisticsIsBoundedAndRepeatable(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, SQLiteInDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	seedRollupsForPlanner(ctx, t, store)
+
+	for i := 0; i < 3; i++ {
+		if err := store.UpdateStatistics(ctx); err != nil {
+			t.Fatalf("update statistics run %d: %v", i, err)
+		}
+	}
+
+	var limit int
+	if err := store.db.QueryRowContext(ctx, "PRAGMA analysis_limit").Scan(&limit); err != nil {
+		t.Fatalf("read analysis limit: %v", err)
+	}
+	if limit != 400 {
+		t.Fatalf("analysis_limit = %d, want 400", limit)
+	}
+}
+
+// TestUpdateStatisticsOnEmptyStore covers the fresh-install path, where Migrate
+// has created the schema but no rollup row exists yet.
+func TestUpdateStatisticsOnEmptyStore(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, SQLiteInDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if err := store.UpdateStatistics(ctx); err != nil {
+		t.Fatalf("update statistics on empty store: %v", err)
+	}
+}
+
+func TestUpdateStatisticsClosedStore(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, SQLiteInDir(t.TempDir()))
+	if err != nil {
+		t.Fatalf("open sqlite store: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	if err := store.UpdateStatistics(ctx); !errors.Is(err, ErrClosed) {
+		t.Fatalf("UpdateStatistics on closed store = %v, want %v", err, ErrClosed)
+	}
+}


### PR DESCRIPTION
已 rebase 到最新 main（`4077201`），无冲突。

## 背景：这个 PR 现在补的是什么

`05a91ad` 把 `rollupTimeBounds` 和 `latestRollupBefore` 改写成 `IN (SELECT ...)` 子查询，用查询结构固定住「先定位 series」的计划，不再依赖优化器判断。**这个改写是有效的**，我在该 commit 上实测确认过：`rollupTimeBounds` 无统计信息 57.3µs、有统计信息 56.7µs，执行计划完全一致——那条路径已经不需要统计信息了。

但 `scanRollupRowsBetween` 没有被改写，而它是 `AggregateRollup` 的主查询，面板每刷新一次、每个节点都要走一遍。在没有 ANALYZE 过的库上，它的计划仍然是原来那个形状。

## 实测

数据集：36600 行 rollup、24 个 entity、1 分钟分辨率，跑在 `4077201` 上。

**无统计信息**（现状）：

```
SEARCH d USING COVERING INDEX sqlite_autoindex_metric_resolutions_1 (resolution_milli=?)
SEARCH r USING INDEX metric_rollups_resolution_bucket_idx (resolution_id=? AND bucket_milli>? AND bucket_milli<?)
SEARCH s USING INTEGER PRIMARY KEY (rowid=?)
SEARCH l USING INTEGER PRIMARY KEY (rowid=?)
```

`r` 是按 `resolution_id` 进入的——扫的是整个分辨率层在该时间窗口内的全部行，与请求的 entity 无关。

**刷新统计信息后**：

```
SEARCH d USING COVERING INDEX sqlite_autoindex_metric_resolutions_1 (resolution_milli=?)
SCAN l
SEARCH s USING INDEX metric_series_metric_entity_idx (metric_name=? AND entity_id=?)
SEARCH r USING INDEX sqlite_autoindex_metric_rollups_1 (series_id=? AND resolution_id=? AND label_id=? AND bucket_milli>? AND bucket_milli<?)
USE TEMP B-TREE FOR ORDER BY
```

| 路径 | 无统计信息 | 有统计信息 |
|---|---|---|
| `scanRollupRowsBetween` 单次 | 2.28 ms | 0.52 ms |
| `Store.Series` 端到端单次 | 2.63 ms | 0.78 ms |

这个差距会随分辨率层增大而扩大，因为被扫的行数正比于「节点数 × 保留时长」，而实际需要的行数只正比于保留时长。

## 改动

把统计信息刷新挂到已有的五分钟 compaction 调度上——那里正是行数变动最大的时刻：

- `Store.UpdateStatistics` 执行 `PRAGMA analysis_limit=400` + `PRAGMA optimize`
- `analysis_limit` 限制每个索引的采样行数，使开销与库大小无关；`PRAGMA optimize` 只重新分析内容变化足够大的表。实测 12.6 万行的库上 4.6ms，不带 `analysis_limit` 的完整 `ANALYZE` 是 40ms 且随库增大显著变慢
- `metricstore.UpdateStatistics` 取共享锁：只对已有行采样，可与上报写入、compaction 并发，但要防止 store 重载在执行中关闭底层连接
- 非 SQLite 后端自行维护统计信息，此处为 no-op

选择 `PRAGMA optimize` 而非建表后一次性 `ANALYZE`，是因为建表时表是空的，那时的统计信息对后续数据量没有意义；`optimize` 是增量的，既能修好现存的库，也能随数据增长自动保持有效。

## 与 `05a91ad` 的关系

两者不冲突，建议都保留，因为覆盖面不同：改写查询是把计划钉死在**那一条语句**上，需要事先知道哪条会退化；统计信息作用于**所有**走这套规范化 schema 的查询，包括以后新增的。上面 `scanRollupRowsBetween` 的数据就是这个差别的直接体现。

如果你更希望统一用改写的方式收口，我也可以把 `scanRollupRowsBetween` 按 `05a91ad` 的风格改成子查询形式，告诉我倾向哪种即可。

## 测试

`pkg/metric/statistics_test.go`：

- `TestUpdateStatisticsRecordsRollupPlan` — 回归守卫。它通过 `querier` 接口捕获 `scanRollupRowsBetween` **实际执行的语句**再做 `EXPLAIN QUERY PLAN`，而不是在测试里复制一份 SQL，这样以后改写该查询不会让守卫对着一条已经不存在的语句空转。断言分两步：先确认未 ANALYZE 的库确实走 `resolution_bucket_idx`（否则说明 seed 已不能复现问题，直接失败），刷新后再断言不走该索引且按 series seek。把实现改成 no-op 时该测试会失败，已验证
- `TestUpdateStatisticsIsBoundedAndRepeatable` — 可重复调用，且 `analysis_limit` 生效
- `TestUpdateStatisticsOnEmptyStore` — 覆盖全新安装（schema 已建、无 rollup 行）
- `TestUpdateStatisticsClosedStore` — 已关闭的 store 返回 `ErrClosed`

`go test ./pkg/metric/ ./internal/metricstore/ -count=1` 通过，`gofmt`/`go vet` 干净。全仓库 `go build ./...` 我这边跑不了，`web/public` 的 `defaultTheme` 前端产物缺失，在未打补丁的 main 上是同样的报错，与本 PR 无关。

## 备注

对于已升级的实例，合并后无需手工干预——下一次 compaction（最多 5 分钟）就会自动生效。想立刻生效的话，对 `metrics.db` 手动执行一次 `ANALYZE` 即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
