### PR TITLE
feat(protocol): expose disk mounts and report extensions

### DIFF
--- a/database/clients/report.go
+++ b/database/clients/report.go
@@ -1,13 +1,25 @@
 package clients
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
+	"regexp"
 
 	"github.com/komari-monitor/komari/database/dbcore"
 	"github.com/komari-monitor/komari/database/models"
 	v1 "github.com/komari-monitor/komari/protocol/v1"
 )
+
+const (
+	maxReportDiskMounts          = 128
+	maxReportDiskStringLength    = 4096
+	maxReportDisksBytes          = 32 * 1024
+	maxReportExtensionNamespaces = 32
+	maxReportExtensionsBytes     = 32 * 1024
+)
+
+var reportExtensionNamespacePattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$`)
 
 func GetClientUUIDByToken(token string) (clientUUID string, err error) {
 	db := dbcore.GetDBInstance()
@@ -76,6 +88,54 @@ func ReportVerify(report v1.Report) error {
 	}
 	if err := checkInt64("Disk.Total", report.Disk.Total); err != nil {
 		return err
+	}
+	if len(report.Disks) > maxReportDiskMounts {
+		return fmt.Errorf("Disks must contain at most %d entries", maxReportDiskMounts)
+	}
+	if len(report.Disks) > 0 {
+		encoded, err := json.Marshal(report.Disks)
+		if err != nil {
+			return fmt.Errorf("Disks must contain valid data: %w", err)
+		}
+		if len(encoded) > maxReportDisksBytes {
+			return fmt.Errorf("Disks must not exceed %d bytes", maxReportDisksBytes)
+		}
+	}
+	for i, disk := range report.Disks {
+		prefix := fmt.Sprintf("Disks[%d]", i)
+		if len(disk.Name) > maxReportDiskStringLength ||
+			len(disk.Device) > maxReportDiskStringLength ||
+			len(disk.Mountpoint) > maxReportDiskStringLength ||
+			len(disk.Filesystem) > maxReportDiskStringLength {
+			return fmt.Errorf("%s contains a string longer than %d bytes", prefix, maxReportDiskStringLength)
+		}
+		if err := checkInt64(prefix+".Used", disk.Used); err != nil {
+			return err
+		}
+		if err := checkInt64(prefix+".Total", disk.Total); err != nil {
+			return err
+		}
+	}
+	if len(report.Extensions) > maxReportExtensionNamespaces {
+		return fmt.Errorf("Extensions must contain at most %d namespaces", maxReportExtensionNamespaces)
+	}
+	if len(report.Extensions) > 0 {
+		encoded, err := json.Marshal(report.Extensions)
+		if err != nil {
+			return fmt.Errorf("Extensions must contain valid JSON: %w", err)
+		}
+		if len(encoded) > maxReportExtensionsBytes {
+			return fmt.Errorf("Extensions must not exceed %d bytes", maxReportExtensionsBytes)
+		}
+		for namespace, raw := range report.Extensions {
+			if !reportExtensionNamespacePattern.MatchString(namespace) {
+				return fmt.Errorf("Extensions namespace %q is invalid", namespace)
+			}
+			var object map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &object); err != nil || object == nil {
+				return fmt.Errorf("Extensions namespace %q must contain a JSON object", namespace)
+			}
+		}
 	}
 	// Network 验证
 	if err := checkInt64("Network.Up", report.Network.Up); err != nil {

--- a/database/clients/report_test.go
+++ b/database/clients/report_test.go
@@ -1,0 +1,76 @@
+package clients
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	v1 "github.com/komari-monitor/komari/protocol/v1"
+)
+
+func TestReportVerifyAcceptsOptionalStatusFields(t *testing.T) {
+	report := v1.Report{
+		Disks: []v1.DiskMount{{
+			Name: "sda1", Device: "/dev/sda1", Mountpoint: "/", Filesystem: "ext4", Total: 100, Used: 40,
+		}},
+		Extensions: v1.ReportExtensions{
+			"example.storage": json.RawMessage(`{"health":"healthy"}`),
+		},
+	}
+	if err := ReportVerify(report); err != nil {
+		t.Fatalf("valid optional status fields were rejected: %v", err)
+	}
+}
+
+func TestReportVerifyRejectsInvalidDiskMounts(t *testing.T) {
+	oversizedPayload := make([]v1.DiskMount, 9)
+	for i := range oversizedPayload {
+		oversizedPayload[i] = v1.DiskMount{Mountpoint: "/data", Device: strings.Repeat("x", 4000)}
+	}
+	tests := []struct {
+		name  string
+		disks []v1.DiskMount
+	}{
+		{name: "negative used", disks: []v1.DiskMount{{Mountpoint: "/", Used: -1}}},
+		{name: "negative total", disks: []v1.DiskMount{{Mountpoint: "/", Total: -1}}},
+		{name: "too many", disks: make([]v1.DiskMount, maxReportDiskMounts+1)},
+		{name: "oversized string", disks: []v1.DiskMount{{Mountpoint: strings.Repeat("x", maxReportDiskStringLength+1)}}},
+		{name: "oversized payload", disks: oversizedPayload},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ReportVerify(v1.Report{Disks: tt.disks}); err == nil {
+				t.Fatal("invalid disk mounts were accepted")
+			}
+		})
+	}
+}
+
+func TestReportVerifyRejectsInvalidExtensions(t *testing.T) {
+	tests := []struct {
+		name       string
+		extensions v1.ReportExtensions
+	}{
+		{name: "invalid namespace", extensions: v1.ReportExtensions{"Example Status": json.RawMessage(`{}`)}},
+		{name: "non-object value", extensions: v1.ReportExtensions{"example": json.RawMessage(`true`)}},
+		{name: "invalid json", extensions: v1.ReportExtensions{"example": json.RawMessage(`{`)}},
+		{name: "oversized payload", extensions: v1.ReportExtensions{
+			"example": json.RawMessage(`{"value":"` + strings.Repeat("x", maxReportExtensionsBytes) + `"}`),
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ReportVerify(v1.Report{Extensions: tt.extensions}); err == nil {
+				t.Fatal("invalid extensions were accepted")
+			}
+		})
+	}
+
+	tooMany := make(v1.ReportExtensions, maxReportExtensionNamespaces+1)
+	for i := 0; i < maxReportExtensionNamespaces+1; i++ {
+		tooMany["example"+strings.Repeat("x", i)] = json.RawMessage(`{}`)
+	}
+	if err := ReportVerify(v1.Report{Extensions: tooMany}); err == nil {
+		t.Fatal("too many extension namespaces were accepted")
+	}
+}

--- a/protocol/v1/report.go
+++ b/protocol/v1/report.go
@@ -1,6 +1,9 @@
 package v1
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type Message struct {
 	Type      string `json:"type"`
@@ -21,9 +24,11 @@ type Report struct {
 	Swap        RamReport         `json:"swap"`
 	Load        LoadReport        `json:"load"`
 	Disk        DiskReport        `json:"disk"`
+	Disks       []DiskMount       `json:"disks,omitempty"`
 	Network     NetworkReport     `json:"network"`
 	Connections ConnectionsReport `json:"connections"`
 	GPU         *GPUDetailReport  `json:"gpu,omitempty"`
+	Extensions  ReportExtensions  `json:"extensions,omitempty"`
 	Uptime      int64             `json:"uptime"`
 	Process     int               `json:"process"`
 	Message     string            `json:"message"`
@@ -73,6 +78,21 @@ type DiskReport struct {
 	Total int64 `json:"total"`
 	Used  int64 `json:"used"`
 }
+
+// DiskMount describes the latest usage reported for one mounted filesystem.
+// Aggregate disk usage remains available in Report.Disk for compatibility.
+type DiskMount struct {
+	Name       string `json:"name,omitempty"`
+	Device     string `json:"device,omitempty"`
+	Mountpoint string `json:"mountpoint"`
+	Filesystem string `json:"filesystem,omitempty"`
+	Total      int64  `json:"total"`
+	Used       int64  `json:"used"`
+}
+
+// ReportExtensions carries optional, namespaced latest-status data. Extension
+// values are JSON objects and are not written to the historical metric store.
+type ReportExtensions map[string]json.RawMessage
 
 type NetworkReport struct {
 	Up        int64 `json:"up"`

--- a/protocol/v1/report_test.go
+++ b/protocol/v1/report_test.go
@@ -1,0 +1,44 @@
+package v1
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestReportOptionalStatusFieldsRoundTrip(t *testing.T) {
+	payload := []byte(`{
+		"disk":{"total":100,"used":40},
+		"disks":[{"name":"sda1","device":"/dev/sda1","mountpoint":"/","filesystem":"ext4","total":100,"used":40}],
+		"extensions":{"example.storage":{"health":"healthy"}}
+	}`)
+
+	var report Report
+	if err := json.Unmarshal(payload, &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if len(report.Disks) != 1 || report.Disks[0].Mountpoint != "/" || report.Disks[0].Used != 40 {
+		t.Fatalf("unexpected disk mounts: %#v", report.Disks)
+	}
+	if got := string(report.Extensions["example.storage"]); !strings.Contains(got, `"health":"healthy"`) {
+		t.Fatalf("unexpected extension: %s", got)
+	}
+
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"disks"`) || !strings.Contains(string(encoded), `"extensions"`) {
+		t.Fatalf("optional status fields were dropped: %s", encoded)
+	}
+}
+
+func TestReportOmitsEmptyOptionalStatusFields(t *testing.T) {
+	encoded, err := json.Marshal(Report{})
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	if strings.Contains(string(encoded), `"disks"`) || strings.Contains(string(encoded), `"extensions"`) {
+		t.Fatalf("empty optional status fields should be omitted: %s", encoded)
+	}
+}

--- a/web/agent/connections.go
+++ b/web/agent/connections.go
@@ -129,7 +129,7 @@ func GetLatestReport() map[string]*v1.Report {
 		if v == nil {
 			continue
 		}
-		item := *v
+		item := cloneReport(*v)
 		reportCopy[k] = &item
 	}
 	return reportCopy
@@ -149,7 +149,7 @@ func RecordReport(report v1.Report) {
 	mu.Lock()
 	defer mu.Unlock()
 	if latest := latestReport[report.UUID]; latest == nil || !report.UpdatedAt.Before(latest.UpdatedAt) {
-		item := report
+		item := cloneReport(report)
 		latestReport[report.UUID] = &item
 	}
 	cutoff := time.Now().UTC().Add(-recentReportRetention)
@@ -158,6 +158,10 @@ func RecordReport(report v1.Report) {
 		recentReports[report.UUID] = reports
 		return
 	}
+	// Optional status details are exposed through the latest-status APIs only.
+	// Avoid duplicating them across the short recent-report window.
+	report.Disks = nil
+	report.Extensions = nil
 	insertAt := sort.Search(len(reports), func(i int) bool {
 		return reports[i].UpdatedAt.After(report.UpdatedAt)
 	})
@@ -177,6 +181,20 @@ func GetRecentReports(uuid string) []v1.Report {
 	}
 	recentReports[uuid] = reports
 	return append([]v1.Report(nil), reports...)
+}
+
+func cloneReport(report v1.Report) v1.Report {
+	cloned := report
+	if report.Disks != nil {
+		cloned.Disks = append([]v1.DiskMount(nil), report.Disks...)
+	}
+	if report.Extensions != nil {
+		cloned.Extensions = make(v1.ReportExtensions, len(report.Extensions))
+		for namespace, raw := range report.Extensions {
+			cloned.Extensions[namespace] = append([]byte(nil), raw...)
+		}
+	}
+	return cloned
 }
 
 func reportsAfter(reports []v1.Report, cutoff time.Time) []v1.Report {

--- a/web/agent/connections_test.go
+++ b/web/agent/connections_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -23,12 +24,22 @@ func TestRecordReportKeepsLatestAndShortRecentWindow(t *testing.T) {
 
 	now := time.Now().UTC()
 	RecordReport(v1.Report{UUID: "node-a", UpdatedAt: now.Add(-2 * time.Minute), CPU: v1.CPUReport{Usage: 10}})
-	RecordReport(v1.Report{UUID: "node-a", UpdatedAt: now.Add(-30 * time.Second), CPU: v1.CPUReport{Usage: 20}})
+	report := v1.Report{
+		UUID: "node-a", UpdatedAt: now.Add(-30 * time.Second), CPU: v1.CPUReport{Usage: 20},
+		Disks:      []v1.DiskMount{{Mountpoint: "/", Total: 100, Used: 40}},
+		Extensions: v1.ReportExtensions{"example": json.RawMessage(`{"health":"healthy"}`)},
+	}
+	RecordReport(report)
 	RecordReport(v1.Report{UUID: "node-a", UpdatedAt: now.Add(-45 * time.Second), CPU: v1.CPUReport{Usage: 15}})
+	report.Disks[0].Used = 99
+	report.Extensions["example"][0] = '['
 
 	recent := GetRecentReports("node-a")
 	if len(recent) != 2 || recent[0].CPU.Usage != 15 || recent[1].CPU.Usage != 20 {
 		t.Fatalf("recent reports = %#v", recent)
+	}
+	if recent[1].Disks != nil || recent[1].Extensions != nil {
+		t.Fatalf("optional latest status leaked into recent reports: %#v", recent[1])
 	}
 	recent[0].CPU.Usage = 99
 	if got := GetRecentReports("node-a"); len(got) != 2 || got[0].CPU.Usage != 15 {
@@ -40,8 +51,13 @@ func TestRecordReportKeepsLatestAndShortRecentWindow(t *testing.T) {
 		t.Fatalf("latest report = %#v", latest["node-a"])
 	}
 	latest["node-a"].CPU.Usage = 99
+	latest["node-a"].Disks[0].Used = 99
+	latest["node-a"].Extensions["example"][0] = '['
 	if got := GetLatestReport()["node-a"]; got == nil || got.CPU.Usage != 20 {
 		t.Fatalf("latest report cache was mutated through returned map: %#v", got)
+	}
+	if got := GetLatestReport()["node-a"]; got.Disks[0].Used != 40 || string(got.Extensions["example"]) != `{"health":"healthy"}` {
+		t.Fatalf("latest optional status was mutated through returned map: %#v", got)
 	}
 
 	DeleteLatestReport("node-a")

--- a/web/rpc/jsonrpc/common.go
+++ b/web/rpc/jsonrpc/common.go
@@ -333,6 +333,7 @@ func getNodesLatestStatus(ctx context.Context, req *rpc.JsonRpcRequest) (any, *r
 		Temp           float32             `json:"temp"`
 		Disk           int64               `json:"disk"`
 		DiskTotal      int64               `json:"disk_total"`
+		Disks          []v1.DiskMount      `json:"disks,omitempty"`
 		NetIn          int64               `json:"net_in"`
 		NetOut         int64               `json:"net_out"`
 		NetTotalUp     int64               `json:"net_total_up"`
@@ -343,6 +344,7 @@ func getNodesLatestStatus(ctx context.Context, req *rpc.JsonRpcRequest) (any, *r
 		Online         bool                `json:"online"`
 		Uptime         int64               `json:"uptime"`
 		Ping           map[string]pingStat `json:"ping"`
+		Extensions     v1.ReportExtensions `json:"extensions,omitempty"`
 	}
 
 	respMap := make(map[string]recordLike, len(latest))
@@ -370,6 +372,7 @@ func getNodesLatestStatus(ctx context.Context, req *rpc.JsonRpcRequest) (any, *r
 			Temp:           0,
 			Disk:           rep.Disk.Used,
 			DiskTotal:      rep.Disk.Total,
+			Disks:          rep.Disks,
 			NetIn:          rep.Network.Down,
 			NetOut:         rep.Network.Up,
 			NetTotalUp:     rep.Network.TotalUp,
@@ -380,6 +383,7 @@ func getNodesLatestStatus(ctx context.Context, req *rpc.JsonRpcRequest) (any, *r
 			Online:         onlineSet[uuid],
 			Uptime:         rep.Uptime,
 			Ping:           stats,
+			Extensions:     rep.Extensions,
 		}
 		respMap[uuid] = rl
 	}


### PR DESCRIPTION
## Summary

Komari reports currently provide aggregate disk usage, but cannot preserve per-mount details or optional current status outside the fixed metric fields. This makes useful client data unavailable to themes and requires another protocol change whenever a new status type is introduced.

This PR adds two optional capabilities to the existing report flow:

- per-mount disk usage alongside the existing aggregate disk values
- bounded, namespaced extension data for optional latest status

Both fields pass through the existing ingestion and latest-status responses. They are intentionally not written to historical metric storage, keeping the change small and avoiding dynamic time-series schemas or database migrations.

The change is backward compatible with existing agents and reports. Payload count, namespace and size limits are validated before data enters the runtime status cache.

## Validation

- `go test ./protocol/v1 ./database/clients ./web/agent ./web/rpc/jsonrpc ./web/api/client`
- `go test -race ./protocol/v1 ./database/clients ./web/agent ./web/rpc/jsonrpc ./web/api/client`